### PR TITLE
fix: clean up sessions on close and handle DELETE /mcp

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,10 @@ const mcpHandler = async (req: express.Request, res: express.Response) => {
         sessionIdGenerator: () => randomUUID(),
         onsessioninitialized: (sessionId) => {
           transports[sessionId] = transport;
+          transport.onclose = () => {
+            delete transports[sessionId];
+            logger.info("MCP session closed", { sessionId });
+          };
           logger.info("MCP session initialized", { sessionId });
         },
       });
@@ -75,6 +79,13 @@ const mcpHandler = async (req: express.Request, res: express.Response) => {
       res
         .status(400)
         .json({ error: "Session ID required for non-initialization requests" });
+      return;
+    }
+
+    // DELETE without a session ID is malformed
+    if (req.method === "DELETE" && !sessionId) {
+      logger.warn("DELETE request without session ID");
+      res.status(400).json({ error: "Session ID required to terminate a session" });
       return;
     }
 
@@ -106,6 +117,7 @@ const mcpHandler = async (req: express.Request, res: express.Response) => {
 // Handle MCP requests on /mcp endpoint
 app.post("/mcp", mcpHandler);
 app.get("/mcp", mcpHandler);
+app.delete("/mcp", mcpHandler);
 
 async function main() {
   const config = getConfig();


### PR DESCRIPTION
Sessions were stored in the transports map on initialization but never
removed, causing a memory leak in long-running servers as every client
connection (including those that later disconnect or crash) kept its
StreamableHTTPServerTransport pinned in memory forever.

Wire transport.onclose inside onsessioninitialized so the session is
removed from the map when the transport closes. The sessionId is
captured by closure, avoiding any race between ID assignment and
cleanup registration.

Also add app.delete('/mcp', mcpHandler) to implement the DELETE method
defined by the Streamable HTTP transport spec for explicit session
termination. The SDK's handleRequest handles DELETE semantics and fires
onclose, which removes the session via the fix above. A guard returns
400 for DELETE requests missing a session ID.

Generated with [Devin](https://devin.ai)

Co-Authored-By: Devin <158243242+devin-ai-integration[bot]@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ending MCP sessions with HTTP `DELETE` requests.
  * Requests without a session ID now return a clear `400` error.
* **Bug Fixes**
  * Improved session cleanup when connections close, helping prevent stale sessions from lingering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->