### PR TITLE
feat: implement MCP logging/setLevel support

### DIFF
--- a/.agents/skills/create-mcp-tool/SKILL.md
+++ b/.agents/skills/create-mcp-tool/SKILL.md
@@ -156,9 +156,15 @@ The baseline currently skips entries in these categories:
 - **Tool response content types** — `tools-call-image`, `tools-call-audio`, `tools-call-embedded-resource`, `tools-call-mixed-content`, `tools-call-with-logging`, `tools-call-with-progress`, `tools-call-sampling`
 - **Resources** — `resources-list`, `resources-read-text`, `resources-read-binary`, `resources-templates-read`, `resources-subscribe`, `resources-unsubscribe`
 - **Prompts** — `prompts-list`, `prompts-get-simple`, `prompts-get-with-args`, `prompts-get-embedded-resource`, `prompts-get-with-image`
-- **Other** — `logging-set-level`, `completion-complete`, `tools-call-elicitation`, `elicitation-sep1034-defaults`, `elicitation-sep1330-enums`, `dns-rebinding-protection`
+- **Other** — `completion-complete`, `tools-call-elicitation`, `elicitation-sep1034-defaults`, `elicitation-sep1330-enums`, `dns-rebinding-protection`
 
 Check `conformance-baseline.yml` for the current full list — it may have been updated since this skill was written. Remove only the entries that your implementation actually satisfies.
+
+> **Important:** If you have already started the container at least once, you must force-recreate it after rebuilding — otherwise the old image is reused and the test will appear to fail even though the implementation is correct:
+>
+> ```bash
+> docker compose up -d --force-recreate --wait --wait-timeout 60
+> ```
 
 ---
 

--- a/conformance-baseline.yml
+++ b/conformance-baseline.yml
@@ -2,9 +2,6 @@
 # Remove an entry when you implement that feature; stale entries cause CI to fail.
 # See README.md for details and a link to the full scenario list.
 server:
-  # Remove when you implement logging level control
-  - logging-set-level
-
   # Remove when you implement argument autocompletion
   - completion-complete
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,10 +10,17 @@ import { getConfig } from "./config.ts";
 
 const getServer = () => {
   const config = getConfig();
-  const server = new McpServer({
-    name: config.SERVER_NAME,
-    version: config.SERVER_VERSION,
-  });
+  const server = new McpServer(
+    {
+      name: config.SERVER_NAME,
+      version: config.SERVER_VERSION,
+    },
+    {
+      capabilities: {
+        logging: {},
+      },
+    },
+  );
 
   server.registerTool(
     "echo",
@@ -25,6 +32,22 @@ const getServer = () => {
       },
     },
     async (args) => {
+      // Example: send an MCP log notification to the client. The client
+      // controls which levels it receives via logging/setLevel.
+      // See: https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/logging
+      try {
+        await server.sendLoggingMessage({
+          level: "debug",
+          data: { message: args.message },
+          logger: "echo",
+        });
+      } catch (error) {
+        // Log notification failures must not prevent the tool from responding.
+        logger.debug("Failed to send MCP log notification", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+
       const data = { echo: args.message };
       return createTextResult(data);
     },


### PR DESCRIPTION
## Summary

Enables the logging capability on McpServer so the SDK automatically
handles logging/setLevel requests from clients and tracks the requested
level per session. sendLoggingMessage in the echo tool demonstrates the
pattern with a link to the spec — the SDK filters notifications against
the client-set level before forwarding them.

Keeps Pino internal logging (stdout/ops) separate from MCP protocol-level
log notifications (client-facing).

Also updates the create-mcp-tool skill to note that the Docker container
must be force-recreated after rebuilding if it has been started before,
to avoid stale-image false failures in conformance tests.

Closes #79

## AI Disclosure

Generated with [Devin](https://devin.ai)

Co-Authored-By: Devin <158243242+devin-ai-integration[bot]@users.noreply.github.com>

I reviewed all the changes.