### PR TITLE
fix: add typecheck via prebuild, fix Pino arg order throughout

### DIFF
--- a/.agents/skills/create-mcp-tool/SKILL.md
+++ b/.agents/skills/create-mcp-tool/SKILL.md
@@ -49,7 +49,7 @@ server.registerTool(
     },
   },
   async (args) => {
-    logger.info("Tool invoked", { toolName: "my_tool", args });
+    logger.info({ toolName: "my_tool", args }, "Tool invoked");
 
     // Your tool logic here
     const result = {
@@ -103,16 +103,16 @@ Return errors in MCP format rather than throwing:
 
 ```typescript
 async (args) => {
-  logger.info("Tool invoked", { toolName: "my_tool", args });
+  logger.info({ toolName: "my_tool", args }, "Tool invoked");
 
   try {
     const result = await doSomething(args.query);
     return createTextResult(result);
   } catch (error) {
-    logger.error("Tool execution failed", {
-      toolName: "my_tool",
-      error: error instanceof Error ? error.message : error,
-    });
+    logger.error(
+      { toolName: "my_tool", error: error instanceof Error ? error.message : String(error) },
+      "Tool execution failed",
+    );
     return {
       content: [{ type: "text", text: `Error: ${error instanceof Error ? error.message : "Unknown error"}` }],
       isError: true,

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,8 +26,8 @@ This is a TypeScript template for building Model Context Protocol (MCP) servers 
 ### Logging
 - **Always use structured logging**: Import and use `logger` from `src/logger.ts`
 - **Never use `console.log`** - use appropriate log levels instead
-- **Include context**: `logger.info("message", { key: value })`
-- **Error logging**: `logger.error("Error message", { error: error.message })`
+- **Include context**: `logger.info({ key: value }, "message")`
+- **Error logging**: `logger.error({ error: error.message }, "Error message")`
 
 ### Configuration
 - **Environment variables**: Add new config to `src/config.ts` with Zod validation
@@ -90,18 +90,18 @@ server.registerTool(
     },
   },
   async (args) => {
-    logger.info("Tool executed", { toolName: "tool_name", args });
-    
+    logger.info({ toolName: "tool_name", args }, "Tool executed");
+
     try {
       // Tool logic here
       const result = await doSomething(args.param1, args.param2);
-      
+
       return createTextResult(result);
     } catch (error) {
-      logger.error("Tool execution failed", { 
-        toolName: "tool_name", 
-        error: error instanceof Error ? error.message : error 
-      });
+      logger.error(
+        { toolName: "tool_name", error: error instanceof Error ? error.message : String(error) },
+        "Tool execution failed",
+      );
       throw error;
     }
   }
@@ -114,12 +114,12 @@ server.registerTool(
 try {
   // Code that might throw
   const result = await riskyOperation();
-  logger.info("Operation succeeded", { result });
+  logger.info({ result }, "Operation succeeded");
 } catch (error) {
-  logger.error("Operation failed", { 
-    error: error instanceof Error ? error.message : error,
-    context: "additional context"
-  });
+  logger.error(
+    { error: error instanceof Error ? error.message : String(error), context: "additional context" },
+    "Operation failed",
+  );
   // Handle error appropriately
 }
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,8 +93,8 @@ The following environment variables are supported (see `src/config.ts`):
 
 - Use appropriate log levels: `error`, `warn`, `info`, `debug`
 - Include relevant context in log messages (user IDs, session IDs, etc.)
-- Log structured data as the second parameter: `logger.info("message", { key: value })`
-- Error logs should include error details: `logger.error("Error message", { error: error.message })`
+- Log structured data as the first parameter, message second: `logger.info({ key: value }, "message")`
+- Error logs should include error details: `logger.error({ error: error.message }, "Error message")`
 - The logger automatically includes trace correlation when OpenTelemetry is configured
 - Use the `logger` from `src/logger.ts` instead of `console.log`
 
@@ -107,5 +107,5 @@ When adding new tools to the MCP server:
 3. Define input schema using Zod for validation
 4. Return responses in MCP content format with JSON stringified data
 5. Handle errors gracefully and return appropriate error messages
-6. Use structured logging to track tool usage: `logger.info("Tool executed", { toolName, args })`
-7. Log errors with context: `logger.error("Tool execution failed", { toolName, error: error.message })`
+6. Use structured logging to track tool usage: `logger.info({ toolName, args }, "Tool executed")`
+7. Log errors with context: `logger.error({ toolName, error: error.message }, "Tool execution failed")`

--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
+    "prebuild": "npm run typecheck",
     "build": "vite build",
     "dev": "node --watch src/index.ts | pino-pretty",
     "start": "node dist/index.js",
     "test": "vitest",
     "test:ci": "vitest run --reporter=json --outputFile=test-results.json",
+    "typecheck": "tsc --noEmit",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "format": "prettier --write src/**/*.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,9 +43,10 @@ const getServer = () => {
         });
       } catch (error) {
         // Log notification failures must not prevent the tool from responding.
-        logger.debug("Failed to send MCP log notification", {
-          error: error instanceof Error ? error.message : String(error),
-        });
+        logger.debug(
+          { error: error instanceof Error ? error.message : String(error) },
+          "Failed to send MCP log notification",
+        );
       }
 
       const data = { echo: args.message };
@@ -75,9 +76,9 @@ const mcpHandler = async (req: express.Request, res: express.Response) => {
           transports[sessionId] = transport;
           transport.onclose = () => {
             delete transports[sessionId];
-            logger.info("MCP session closed", { sessionId });
+            logger.info({ sessionId }, "MCP session closed");
           };
-          logger.info("MCP session initialized", { sessionId });
+          logger.info({ sessionId }, "MCP session initialized");
         },
       });
 
@@ -114,7 +115,7 @@ const mcpHandler = async (req: express.Request, res: express.Response) => {
 
     // Handle unknown session
     if (sessionId && !transports[sessionId]) {
-      logger.warn("Request for unknown session", { sessionId });
+      logger.warn({ sessionId }, "Request for unknown session");
       res.status(404).json({ error: "Session not found" });
       return;
     }
@@ -130,9 +131,10 @@ const mcpHandler = async (req: express.Request, res: express.Response) => {
       });
     }
   } catch (error) {
-    logger.error("Error handling MCP request", {
-      error: error instanceof Error ? error.message : error,
-    });
+    logger.error(
+      { error: error instanceof Error ? error.message : String(error) },
+      "Error handling MCP request",
+    );
     res.status(500).json({ error: "Internal server error" });
   }
 };
@@ -158,19 +160,20 @@ async function main() {
 
   app.listen(config.PORT, () => {
     logger.info(
-      `MCP TypeScript Template Server running on port ${config.PORT}`,
       {
         environment: config.NODE_ENV,
         serverName: config.SERVER_NAME,
         version: config.SERVER_VERSION,
       },
+      `MCP TypeScript Template Server running on port ${config.PORT}`,
     );
   });
 }
 
 main().catch((error) => {
-  logger.error("Server startup error", {
-    error: error instanceof Error ? error.message : error,
-  });
+  logger.error(
+    { error: error instanceof Error ? error.message : String(error) },
+    "Server startup error",
+  );
   process.exit(1);
 });

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -10,32 +10,44 @@ describe("createTextResult", () => {
 
   it("should create a CallToolResult with correct structure", () => {
     const result = createTextResult(mockData);
+    const item = result.content[0];
 
     expect(result).toHaveProperty("content");
     expect(result.content).toHaveLength(1);
-    expect(result.content[0]).toHaveProperty("type", "text");
-    expect(result.content[0]).toHaveProperty("text");
-    expect(typeof result.content[0].text).toBe("string");
+    expect(item).toHaveProperty("type", "text");
+    expect(item).toHaveProperty("text");
+    if (item.type === "text") {
+      expect(typeof item.text).toBe("string");
+    }
   });
 
   it("should handle mock data correctly", () => {
     const result = createTextResult(mockData);
+    const item = result.content[0];
 
-    expect(result.content[0].type).toBe("text");
-    expect(result.content[0].text).toContain('"echo": "Hello world"');
+    expect(item.type).toBe("text");
+    if (item.type === "text") {
+      expect(item.text).toContain('"echo": "Hello world"');
+    }
   });
 
   it("should handle null data", () => {
     const result = createTextResult(null);
+    const item = result.content[0];
 
-    expect(result.content[0].type).toBe("text");
-    expect(result.content[0].text).toBe("null");
+    expect(item.type).toBe("text");
+    if (item.type === "text") {
+      expect(item.text).toBe("null");
+    }
   });
 
   it("should handle undefined data gracefully by converting to null", () => {
     const result = createTextResult(undefined);
+    const item = result.content[0];
 
-    expect(result.content[0].type).toBe("text");
-    expect(result.content[0].text).toBe("null");
+    expect(item.type).toBe("text");
+    if (item.type === "text") {
+      expect(item.text).toBe("null");
+    }
   });
 });


### PR DESCRIPTION
## Summary

When I initially set up the project I must have forgot to add type checking as part of the build. 🙈 

- Add `typecheck` script (`tsc --noEmit`) to package.json
- Add `prebuild` script that runs typecheck before every build
- Fix all Pino logger calls to use the correct object-first, message-second
  overload — `logger.info({ key: value }, "message")` — throughout
  src/index.ts and all doc/skill examples (CLAUDE.md,
  copilot-instructions.md, SKILL.md)
- Narrow content union type in utils.test.ts before accessing `.text`

Generated with [Devin](https://devin.ai)

## Related Issues

Discovered post #79. I had forgot to check in a type fix, which opened the can of worms that I was type checking in CI.

## AI Disclosure

Co-Authored-By: Devin <158243242+devin-ai-integration[bot]@users.noreply.github.com>

I reviewed and made some manual edits as well.