### PR TITLE
feat: add elicit_echo tool demonstrating MCP elicitation

### DIFF
--- a/.agents/skills/create-mcp-tool/SKILL.md
+++ b/.agents/skills/create-mcp-tool/SKILL.md
@@ -16,12 +16,14 @@ This skill walks you through adding a new tool to the MCP server. If you need to
 
 | Concern | Location |
 |---|---|
-| Tool registration | `src/index.ts` inside the `getServer()` function |
-| Response formatting | `createTextResult()` from `src/lib/utils.ts` |
-| Input validation | Zod schemas defined inline in `server.registerTool()` |
-| Tests | `src/lib/<tool-name>.test.ts` (colocated with logic, or alongside the tool) |
+| Tool registration | `src/tools.ts` inside `registerTools(server)` via `server.registerTool()` |
+| Tool logic | `src/tools.ts` — functions that take only the dependencies they need |
+| Response formatting | `createTextResult()` / `createErrorResult()` from `src/lib/utils.ts` |
+| Input validation | Zod `inputSchema` defined inline in `server.registerTool()` |
+| Typed output | `outputSchema` + `structuredContent` (emitted automatically by `createTextResult`) |
+| Tests | `src/tools.test.ts` (colocated with `src/tools.ts`) |
 
-The `getServer()` function is called once per MCP session, so each session gets its own isolated `McpServer` instance. All tools must be registered inside it.
+Everything for a tool lives in `src/tools.ts`. `registerTools(server)` is the single source of truth for tool wiring — it's called from `getServer()` in `src/index.ts` **and** reused by the tests, so registration can never drift from what's tested. Each tool's implementation is a function that takes only the dependencies it needs (e.g. the bound `elicitInput` function, `sendLoggingMessage`, and the `extra` object), which keeps it small and easy to drive through every branch. `index.ts` owns only HTTP routing and session lifecycle; each session gets its own isolated `McpServer` instance.
 
 ---
 
@@ -35,7 +37,7 @@ The tool's `description` and every Zod field's `.describe()` are how LLM clients
 
 ## Step 2: Register the Tool
 
-Open `src/index.ts` and add a `server.registerTool()` call inside `getServer()`, following the pattern of the existing `echo` tool:
+Open `src/tools.ts` and add a `server.registerTool(...)` call inside `registerTools`, following the pattern of the existing `echo` tool:
 
 ```typescript
 server.registerTool(
@@ -47,26 +49,39 @@ server.registerTool(
       query: z.string().describe("The input to process — be specific about format or constraints"),
       limit: z.number().int().min(1).max(100).optional().describe("Maximum number of results to return (default: 10)"),
     },
+    // Declare the shape of a successful result so clients can consume
+    // structuredContent (createTextResult emits it automatically).
+    outputSchema: {
+      output: z.string().describe("The processed output"),
+      count: z.number().describe("Number of results"),
+    },
+    annotations: { readOnlyHint: true, openWorldHint: false },
   },
-  async (args) => {
-    logger.info({ toolName: "my_tool", args }, "Tool invoked");
-
-    // Your tool logic here
-    const result = {
-      output: args.query,
-      count: 1,
-    };
-
-    return createTextResult(result);
-  },
+  (args, extra) => myTool(args, extra),
 );
 ```
 
+Then implement `myTool` as a function lower in the file:
+
+```typescript
+async function myTool(
+  args: { query: string; limit?: number },
+  extra: { sessionId?: string; requestId: unknown },
+): Promise<CallToolResult> {
+  const toolName = "my_tool";
+  const { sessionId, requestId } = extra;
+
+  const result = { output: args.query, count: 1 };
+  logger.info({ toolName, sessionId, requestId }, "Tool executed");
+  return createTextResult(result);
+}
+```
+
 Key points:
-- `inputSchema` takes an object of Zod field definitions (not a full `z.object()` — just the shape)
-- Always return `createTextResult(data)` for text responses
-- Log tool invocations with `logger.info` and errors with `logger.error`
-- For non-trivial logic, extract it into a helper function in `src/lib/<tool-name>.ts` and import it — this keeps `getServer()` readable and makes unit testing easier
+- `inputSchema` / `outputSchema` take an object of Zod field definitions (not a full `z.object()` — just the shape)
+- Return `createTextResult(data)` on success — it emits both a text block and `structuredContent` for `outputSchema`-aware clients ([structured content](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content))
+- Keep the tool's logic in a function that receives only the dependencies it needs (e.g. `elicitInput`, `sendLoggingMessage`, `extra`); pass them from the registration callback with `.bind()` where needed. This keeps each tool small and testable
+- Log tool execution with `logger.info` and failures with `logger.error`, including `sessionId` and `requestId` from `extra` for traceability
 
 ### Tool Annotations
 
@@ -99,45 +114,111 @@ server.registerTool(
 
 ## Step 3: Handle Errors
 
-Return errors in MCP format rather than throwing:
+Report execution failures in-band with `createErrorResult` (which sets `isError: true`) rather than throwing — this lets the client/model distinguish a failure from a normal result. Reserve `isError` for genuine failures; valid outcomes (e.g. a user declining an elicitation, or an empty search) are normal results via `createTextResult`. See [Error Handling](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#error-handling) in the spec.
 
 ```typescript
-async (args) => {
-  logger.info({ toolName: "my_tool", args }, "Tool invoked");
+async function myTool(args, extra) {
+  const toolName = "my_tool";
+  const { sessionId, requestId } = extra;
 
   try {
     const result = await doSomething(args.query);
+    logger.info({ toolName, sessionId, requestId }, "Tool executed");
     return createTextResult(result);
   } catch (error) {
     logger.error(
-      { toolName: "my_tool", error: error instanceof Error ? error.message : String(error) },
+      { toolName, sessionId, requestId, error: error instanceof Error ? error.message : String(error) },
       "Tool execution failed",
     );
-    return {
-      content: [{ type: "text", text: `Error: ${error instanceof Error ? error.message : "Unknown error"}` }],
-      isError: true,
-    };
+    return createErrorResult({
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
-},
+}
 ```
 
 ---
 
 ## Step 4: Write Tests
 
-Add a test file at `src/lib/<tool-name>.test.ts`. Follow the pattern in `src/lib/utils.test.ts`:
+Add tests to `src/tools.test.ts`, colocated with `src/tools.ts`. Tests use `InMemoryTransport` to wire up a real client/server pair in-process, exercising the full MCP protocol stack (tool registration, request/response, elicitation) with only the user-facing parts mocked.
+
+Follow the existing pattern:
 
 ```typescript
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTools } from "./tools.ts";
+
+let harness: { client: Client; server: McpServer } | undefined;
+
+afterEach(async () => {
+  if (harness) {
+    await harness.server.close();
+    await harness.client.close();
+    harness = undefined;
+  }
+});
+
+async function setupClientServer() {
+  const server = new McpServer(
+    { name: "test-server", version: "0.0.0" },
+    { capabilities: { logging: {} } },
+  );
+  registerTools(server);
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client(
+    { name: "test-client", version: "0.0.0" },
+    { capabilities: { elicitation: {} } },
+  );
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  harness = { client, server };
+  return harness;
+}
+
+function parseContent(result: unknown): Record<string, unknown> {
+  const parsed = CallToolResultSchema.safeParse(result);
+  expect(parsed.success).toBe(true);
+  if (!parsed.success) {
+    throw new Error("callTool result did not match CallToolResult schema");
+  }
+  const item = parsed.data.content[0];
+  expect(item.type).toBe("text");
+  if (item.type !== "text") {
+    throw new Error("expected text content");
+  }
+  return JSON.parse(item.text);
+}
 
 describe("my_tool", () => {
-  it("should return the expected output", () => {
-    // Test your tool's core logic directly (extract it into a helper function if needed)
-    const result = { output: "hello", count: 1 };
-    expect(result.output).toBe("hello");
+  it("returns the expected output", async () => {
+    const { client } = await setupClientServer();
+
+    const result = await client.callTool({
+      name: "my_tool",
+      arguments: { query: "hello" },
+    });
+
+    const parsed = parseContent(result);
+    expect(parsed.output).toBe("hello");
   });
 });
 ```
+
+Key points:
+- Use `InMemoryTransport.createLinkedPair()` to connect a real `Client` and `McpServer` in-process — no HTTP server needed
+- Connect the server before the client (`server.connect` then `client.connect`) so the initialize handshake completes
+- Use `afterEach` to close both sides leak-safely, even if assertions fail
+- The existing `setupClientServer` takes an options object — pass `elicitHandler` to answer elicitation, `supportsElicitation: false` to test the unsupported-client path, and `onLog` to capture outbound logging notifications. Reuse it rather than adding new helpers
+- Use `CallToolResultSchema.safeParse()` to validate and narrow the `callTool` return type before asserting on content
+- Assert `result.structuredContent` for `outputSchema`-aware output, and `result.isError` to confirm failures are flagged (and that valid outcomes are *not*)
 
 Run tests with:
 
@@ -153,7 +234,7 @@ npm run test
 npm run build        # compile TypeScript
 npm run lint         # ESLint
 npm run format:check # Prettier formatting check
-npm run test         # Vitest unit tests
+npm run test:ci      # Vitest (non-interactive, outputs test-results.json)
 npm run dev          # start server with hot reload for manual testing
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,11 +37,13 @@ npm run lint && npm run format:check && npm run build && npm run test:ci
 
 ```
 src/
-  index.ts       # MCP server entry point — tool registration, HTTP routing
+  index.ts       # HTTP routing, session lifecycle; calls registerTools() in getServer()
+  tools.ts       # registerTools() wiring + per-tool logic functions
+  tools.test.ts  # colocated integration tests (in-memory client/server)
   config.ts      # Env var validation via Zod
   logger.ts      # Pino structured logging (OpenTelemetry compatible)
   lib/
-    utils.ts       # MCP response helpers
+    utils.ts       # MCP response helpers (createTextResult, createErrorResult)
     utils.test.ts  # colocated unit tests
 dist/            # compiled output (ES modules)
 ```
@@ -51,9 +53,9 @@ Config files (`vite.config.ts`, `tsconfig.json`, `eslint.config.js`, `Dockerfile
 ## Architecture
 
 - HTTP transport via Express on `PORT` (default 3000) — **not** stdio
-- Tools registered with `server.registerTool()` in `src/index.ts`
-- All tool responses use MCP `content` format: `[{ type: 'text', text: JSON.stringify(data) }]`
-- Errors returned as MCP-formatted messages, not thrown
+- Tools registered via `registerTools(server)` in `src/tools.ts`, the single source of truth for tool wiring — called from `getServer()` in `src/index.ts` and reused by the tests
+- Tool responses use `createTextResult` / `createErrorResult` from `src/lib/utils.ts`: a text `content` block plus `structuredContent` (for clients that declare an `outputSchema`)
+- Genuine execution failures return `isError: true` (via `createErrorResult`), not thrown; valid outcomes (e.g. a user declining an elicitation) are normal results
 - Session lifecycle managed via `StreamableHTTPServerTransport`
 - Graceful shutdown on `SIGTERM`/`SIGINT`
 
@@ -99,12 +101,15 @@ Log levels: `error` > `warn` > `info` > `debug`. Include relevant IDs (session, 
 
 ## Adding a New Tool
 
-1. Call `server.registerTool()` in `src/index.ts`
-2. Provide a `title`, `description`, and Zod `inputSchema`
-3. Return `{ content: [{ type: 'text', text: JSON.stringify(result) }] }`
-4. Handle errors and return an error content response — don't throw
+See the `create-mcp-tool` skill (`.agents/skills/create-mcp-tool`) for the full walkthrough. In short:
+
+1. Add the `server.registerTool()` call inside `registerTools()` in `src/tools.ts`
+2. Provide a `title`, `description`, Zod `inputSchema`, an `outputSchema`, and `annotations` (e.g. `readOnlyHint`)
+3. Return `createTextResult(result)` on success (it also emits `structuredContent`)
+4. On genuine failure return `createErrorResult({ error })` (sets `isError: true`); don't throw
 5. Log with `logger.info({ toolName, args }, "Tool executed")` on success
 6. Log with `logger.error({ toolName, error: error.message }, "Tool execution failed")` on failure
+7. Add integration tests to `src/tools.test.ts` (import `registerTools`, wire an in-memory client/server)
 
 ## Testing
 
@@ -120,7 +125,7 @@ To build your own MCP server from this template:
 
 1. Update `package.json` (name, description, version)
 2. Add/replace env vars in `src/config.ts`
-3. Replace the `echo` tool in `src/index.ts` with your tools
+3. Replace the `echo` / `elicit_echo` tools in `src/tools.ts` with your tools
 4. Add business logic under `src/`
 5. Update `README.md` and this `AGENTS.md` to reflect your project
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This template provides:
 - **Express** - Fast, unopinionated web framework for HTTP server
 - **ESLint + Prettier** - Code quality and formatting
 - **Docker** - Containerization support
-- **Example Tool** - Simple echo tool to demonstrate MCP tool implementation
+- **Example Tools** - `echo` and `elicit_echo` tools demonstrating tool implementation, structured output, annotations, and MCP elicitation
 
 ## Getting Started
 
@@ -113,7 +113,7 @@ Make sure your server is running (using `npm start` or `npm run dev`) before con
 
 ## Available Tools
 
-The template includes one example tool:
+The template includes two example tools:
 
 ### echo
 
@@ -123,10 +123,16 @@ Echoes back the provided message - a simple example to demonstrate MCP tool impl
 
 - `message` (string) - The message to echo back
 
+### elicit_echo
+
+Demonstrates [MCP elicitation](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation): the tool takes no input, asks the connected client to prompt the user for a message, then echoes it back. Handles all three elicitation outcomes (accept, decline, cancel) and errors when the client doesn't support elicitation.
+
+Both tools declare an `outputSchema` and return `structuredContent` alongside the text result, and carry `annotations` (`readOnlyHint`, `idempotentHint`, `openWorldHint`) describing their safety profile.
+
 ## Customizing Your MCP Server
 
 1. **Update package.json** - Change name, description, and keywords
-2. **Modify src/index.ts** - Replace the echo tool with your custom tools
+2. **Modify src/tools.ts** - Replace the `echo` / `elicit_echo` tools with your custom tools
 3. **Add your logic** - Create additional TypeScript files for your business logic
 4. **Update README** - Document your specific MCP server functionality
 
@@ -159,14 +165,20 @@ docker compose up --build
 ```
 mcp-typescript-template/
 ├── src/
-│   └── index.ts          # Main MCP server entry point
+│   ├── index.ts          # HTTP routing + session lifecycle
+│   ├── tools.ts          # Tool registration (registerTools) and logic
+│   ├── tools.test.ts     # Integration tests (in-memory client/server)
+│   ├── config.ts         # Env var validation (Zod)
+│   ├── logger.ts         # Pino structured logging
+│   └── lib/
+│       ├── utils.ts      # MCP response helpers
+│       └── utils.test.ts # Unit tests
 ├── dist/                 # Built output (generated)
-├── .eslintrc.js         # ESLint configuration
-├── .prettierrc          # Prettier configuration
-├── tsconfig.json        # TypeScript configuration
-├── vite.config.ts       # Vite build configuration
-├── Dockerfile           # Docker configuration
-└── package.json         # Dependencies and scripts
+├── tsconfig.json         # TypeScript configuration
+├── vite.config.ts        # Vite build configuration
+├── eslint.config.js      # ESLint configuration
+├── Dockerfile            # Docker configuration
+└── package.json          # Dependencies and scripts
 ```
 
 ## Architecture
@@ -174,14 +186,17 @@ mcp-typescript-template/
 This template follows a simple architecture:
 
 - **HTTP Transport** - Uses Express with StreamableHTTPServerTransport for remote MCP connections
-- **Tool Registration** - Tools are registered with JSON schemas for input validation
-- **Error Handling** - Proper MCP-formatted error responses
+- **Tool Registration** - `registerTools(server)` in `src/tools.ts` is the single source of truth for tool wiring; `getServer()` and the tests both use it
+- **Typed I/O** - Zod `inputSchema` for validation, plus `outputSchema` + `structuredContent` for typed results
+- **Error Handling** - Genuine failures return `isError: true` via `createErrorResult`; results are never thrown
 - **Session Management** - Handles MCP session initialization and management
 
 ## Example: Adding a New Tool
 
+Add the registration inside `registerTools()` in `src/tools.ts`. See the `create-mcp-tool` skill (`.agents/skills/create-mcp-tool`) for the full walkthrough.
+
 ```typescript
-import { createTextResult } from "./lib/utils.js";
+import { createErrorResult, createTextResult } from "./lib/utils.ts";
 
 server.registerTool(
   "my_tool",
@@ -192,12 +207,20 @@ server.registerTool(
       param1: z.string().describe("Description of param1"),
       param2: z.number().optional().describe("Optional parameter"),
     },
+    outputSchema: {
+      output: z.string().describe("Description of the result"),
+    },
+    annotations: { readOnlyHint: true, openWorldHint: false },
   },
   async (args) => {
-    // Your tool logic here
-    const result = await myCustomLogic(args.param1, args.param2);
-
-    return createTextResult(result);
+    try {
+      const result = await myCustomLogic(args.param1, args.param2);
+      return createTextResult(result);
+    } catch (error) {
+      return createErrorResult({
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   },
 );
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,9 @@ import { randomUUID } from "node:crypto";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
-import { z } from "zod";
-import { createTextResult } from "./lib/utils.ts";
 import { logger } from "./logger.ts";
 import { getConfig } from "./config.ts";
+import { registerTools } from "./tools.ts";
 
 const getServer = () => {
   const config = getConfig();
@@ -22,95 +21,7 @@ const getServer = () => {
     },
   );
 
-  server.registerTool(
-    "elicit_echo",
-    {
-      title: "Elicit Echo",
-      description:
-        "Ask the user what they want to echo back, then echoes it",
-    },
-    async (extra) => {
-      const toolName = "elicit_echo";
-      const { sessionId, requestId } = extra;
-      try {
-        const result = await server.server.elicitInput({
-          message: "What would you like to echo?",
-          requestedSchema: {
-            type: "object",
-            properties: {
-              message: {
-                type: "string",
-                title: "Message",
-                description: "The message to echo back",
-              },
-            },
-            required: ["message"],
-          },
-        });
-
-        if (result.action === "accept") {
-          if (!result.content) {
-            logger.warn({ toolName, sessionId, requestId }, "Accept response missing content");
-            return createTextResult({ error: "Accepted but no content was returned" });
-          }
-          const data = { echo: result.content.message };
-          logger.info({ toolName, sessionId, requestId }, "Tool executed");
-          return createTextResult(data);
-        }
-
-        if (result.action === "decline") {
-          logger.info({ toolName, sessionId, requestId, action: "decline" }, "User declined elicitation");
-          return createTextResult({ echo: null, reason: "User declined to provide a message" });
-        }
-
-        logger.info({ toolName, sessionId, requestId, action: "cancel" }, "User cancelled elicitation");
-        return createTextResult({ echo: null, reason: "Elicitation was cancelled" });
-      } catch (error) {
-        logger.error(
-          { toolName, sessionId, requestId, error: error instanceof Error ? error.message : String(error) },
-          "Tool execution failed",
-        );
-        return createTextResult({
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-    },
-  );
-
-  server.registerTool(
-    "echo",
-    {
-      title: "Echo",
-      description: "Echo back the provided message",
-      inputSchema: {
-        message: z.string().describe("The message to echo back"),
-      },
-    },
-    async (args, extra) => {
-      const toolName = "echo";
-      const { sessionId, requestId } = extra;
-      // Example: send an MCP log notification to the client. The client
-      // controls which levels it receives via logging/setLevel.
-      // See: https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/logging
-      try {
-        await server.sendLoggingMessage({
-          level: "debug",
-          data: { message: args.message },
-          logger: "echo",
-        });
-      } catch (error) {
-        // Log notification failures must not prevent the tool from responding.
-        logger.debug(
-          { error: error instanceof Error ? error.message : String(error) },
-          "Failed to send MCP log notification",
-        );
-      }
-
-      const data = { echo: args.message };
-      logger.info({ toolName, sessionId, requestId }, "Tool executed");
-      return createTextResult(data);
-    },
-  );
+  registerTools(server);
 
   return server;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,61 @@ const getServer = () => {
   );
 
   server.registerTool(
+    "elicit_echo",
+    {
+      title: "Elicit Echo",
+      description:
+        "Ask the user what they want to echo back, then echoes it",
+    },
+    async (extra) => {
+      const toolName = "elicit_echo";
+      const { sessionId, requestId } = extra;
+      try {
+        const result = await server.server.elicitInput({
+          message: "What would you like to echo?",
+          requestedSchema: {
+            type: "object",
+            properties: {
+              message: {
+                type: "string",
+                title: "Message",
+                description: "The message to echo back",
+              },
+            },
+            required: ["message"],
+          },
+        });
+
+        if (result.action === "accept") {
+          if (!result.content) {
+            logger.warn({ toolName, sessionId, requestId }, "Accept response missing content");
+            return createTextResult({ error: "Accepted but no content was returned" });
+          }
+          const data = { echo: result.content.message };
+          logger.info({ toolName, sessionId, requestId }, "Tool executed");
+          return createTextResult(data);
+        }
+
+        if (result.action === "decline") {
+          logger.info({ toolName, sessionId, requestId, action: "decline" }, "User declined elicitation");
+          return createTextResult({ echo: null, reason: "User declined to provide a message" });
+        }
+
+        logger.info({ toolName, sessionId, requestId, action: "cancel" }, "User cancelled elicitation");
+        return createTextResult({ echo: null, reason: "Elicitation was cancelled" });
+      } catch (error) {
+        logger.error(
+          { toolName, sessionId, requestId, error: error instanceof Error ? error.message : String(error) },
+          "Tool execution failed",
+        );
+        return createTextResult({
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    },
+  );
+
+  server.registerTool(
     "echo",
     {
       title: "Echo",
@@ -31,7 +86,9 @@ const getServer = () => {
         message: z.string().describe("The message to echo back"),
       },
     },
-    async (args) => {
+    async (args, extra) => {
+      const toolName = "echo";
+      const { sessionId, requestId } = extra;
       // Example: send an MCP log notification to the client. The client
       // controls which levels it receives via logging/setLevel.
       // See: https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/logging
@@ -50,6 +107,7 @@ const getServer = () => {
       }
 
       const data = { echo: args.message };
+      logger.info({ toolName, sessionId, requestId }, "Tool executed");
       return createTextResult(data);
     },
   );

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { createTextResult } from "./utils.ts";
+import { createErrorResult, createTextResult } from "./utils.ts";
 
 describe("createTextResult", () => {
   // Mock data for testing
@@ -48,6 +48,33 @@ describe("createTextResult", () => {
     expect(item.type).toBe("text");
     if (item.type === "text") {
       expect(item.text).toBe("null");
+    }
+  });
+
+  it("should attach structuredContent for object payloads", () => {
+    const result = createTextResult(mockData);
+    expect(result.structuredContent).toEqual(mockData);
+  });
+
+  it("should not attach structuredContent for non-object payloads", () => {
+    expect(createTextResult(null).structuredContent).toBeUndefined();
+    expect(createTextResult("plain string").structuredContent).toBeUndefined();
+  });
+
+  it("should not flag success results as errors", () => {
+    expect(createTextResult(mockData).isError).toBeFalsy();
+  });
+});
+
+describe("createErrorResult", () => {
+  it("flags the result as an error while keeping the text/structured payload", () => {
+    const result = createErrorResult({ error: "boom" });
+    const item = result.content[0];
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toEqual({ error: "boom" });
+    if (item.type === "text") {
+      expect(item.text).toContain('"error": "boom"');
     }
   });
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,16 +1,26 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 /**
- * Creates a CallToolResult with text content from any data
- * Handles undefined values gracefully by converting them to null
- * @param data - The data to stringify and include in the result
+ * Creates a successful CallToolResult from any data.
+ *
+ * The same data is returned two ways, per the MCP 2025-06-18 spec:
+ *   - `content`: a human/legacy-client readable text block (the fallback).
+ *   - `structuredContent`: the raw object for clients that declare an
+ *     `outputSchema`. When a tool declares an outputSchema, the SDK
+ *     validates this field against it.
+ * The spec requires that a tool returning structured content SHOULD also
+ * return the serialized JSON as a text block — which is why we emit both.
+ * See: https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content
+ *
+ * Handles undefined values gracefully by converting them to null.
+ * @param data - The data to include in the result
  * @returns A properly formatted CallToolResult
  */
 export function createTextResult(data: unknown): CallToolResult {
   // Handle undefined gracefully by converting to null
   const safeData = data === undefined ? null : data;
 
-  return {
+  const result: CallToolResult = {
     content: [
       {
         type: "text",
@@ -18,4 +28,28 @@ export function createTextResult(data: unknown): CallToolResult {
       },
     ],
   };
+
+  // Only objects can satisfy an outputSchema (JSON Schema `type: "object"`),
+  // so we only attach structuredContent for object payloads.
+  if (safeData !== null && typeof safeData === "object") {
+    result.structuredContent = safeData as Record<string, unknown>;
+  }
+
+  return result;
+}
+
+/**
+ * Creates a failed CallToolResult with `isError: true`.
+ *
+ * Per the MCP spec, tool *execution* errors should be reported in-band with
+ * `isError: true` (not thrown), so the model/client can distinguish a failure
+ * from a normal result and react to it. Reserve this for genuine failures —
+ * outcomes like a user declining or cancelling an elicitation are valid
+ * results and should use createTextResult instead.
+ * See: https://modelcontextprotocol.io/specification/2025-06-18/server/tools#error-handling
+ * @param data - The error payload to include in the result
+ * @returns A CallToolResult flagged as an error
+ */
+export function createErrorResult(data: unknown): CallToolResult {
+  return { ...createTextResult(data), isError: true };
 }

--- a/src/tools.test.ts
+++ b/src/tools.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, describe, it, expect } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { CallToolResultSchema, ElicitRequestSchema, type ElicitResult } from "@modelcontextprotocol/sdk/types.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTools } from "./tools.ts";
+
+type TestHarness = {
+  client: Client;
+  server: McpServer;
+};
+
+let harness: TestHarness | undefined;
+
+afterEach(async () => {
+  if (harness) {
+    await harness.server.close();
+    await harness.client.close();
+    harness = undefined;
+  }
+});
+
+/**
+ * Wires up an in-memory client/server pair for integration testing.
+ * When an elicitHandler is provided, the client advertises elicitation
+ * support and routes elicitation requests to it. When omitted, the
+ * client still advertises elicitation support (so non-elicitation tools
+ * can be tested) but does not handle elicitation requests.
+ */
+async function setupClientServer(elicitHandler?: (request: { message: string }) => Promise<ElicitResult>) {
+  const server = new McpServer(
+    { name: "test-server", version: "0.0.0" },
+    { capabilities: { logging: {} } },
+  );
+  registerTools(server);
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  const client = new Client(
+    { name: "test-client", version: "0.0.0" },
+    { capabilities: { elicitation: {} } },
+  );
+
+  if (elicitHandler) {
+    client.setRequestHandler(ElicitRequestSchema, async (request) => {
+      return elicitHandler({ message: request.params.message });
+    });
+  }
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  harness = { client, server };
+  return harness;
+}
+
+/**
+ * Like setupClientServer but the client does NOT advertise elicitation
+ * support, so server.server.elicitInput() will throw.
+ */
+async function setupClientServerWithoutElicitation() {
+  const server = new McpServer(
+    { name: "test-server", version: "0.0.0" },
+    { capabilities: { logging: {} } },
+  );
+  registerTools(server);
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  const client = new Client(
+    { name: "test-client", version: "0.0.0" },
+    { capabilities: {} },
+  );
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  harness = { client, server };
+  return harness;
+}
+
+function parseContent(result: unknown): Record<string, unknown> {
+  const parsed = CallToolResultSchema.safeParse(result);
+  expect(parsed.success).toBe(true);
+  if (!parsed.success) {
+    throw new Error("callTool result did not match CallToolResult schema");
+  }
+  const item = parsed.data.content[0];
+  expect(item.type).toBe("text");
+  if (item.type !== "text") {
+    throw new Error("expected text content");
+  }
+  return JSON.parse(item.text);
+}
+
+describe("echo tool", () => {
+  it("echoes back the provided message", async () => {
+    const { client } = await setupClientServer();
+
+    const result = await client.callTool({
+      name: "echo",
+      arguments: { message: "hello" },
+    });
+
+    const parsed = parseContent(result);
+    expect(parsed.echo).toBe("hello");
+  });
+});
+
+describe("elicit_echo tool", () => {
+  it("echoes the message the user provides via elicitation", async () => {
+    const { client } = await setupClientServer(async () => ({
+      action: "accept",
+      content: { message: "elicited hello" },
+    }));
+
+    const result = await client.callTool({
+      name: "elicit_echo",
+      arguments: {},
+    });
+
+    const parsed = parseContent(result);
+    expect(parsed.echo).toBe("elicited hello");
+  });
+
+  it("returns a decline response when the user declines", async () => {
+    const { client } = await setupClientServer(async () => ({
+      action: "decline",
+    }));
+
+    const result = await client.callTool({
+      name: "elicit_echo",
+      arguments: {},
+    });
+
+    const parsed = parseContent(result);
+    expect(parsed.echo).toBeNull();
+    expect(parsed.reason).toBe("User declined to provide a message");
+  });
+
+  it("returns a cancel response when the user cancels", async () => {
+    const { client } = await setupClientServer(async () => ({
+      action: "cancel",
+    }));
+
+    const result = await client.callTool({
+      name: "elicit_echo",
+      arguments: {},
+    });
+
+    const parsed = parseContent(result);
+    expect(parsed.echo).toBeNull();
+    expect(parsed.reason).toBe("Elicitation was cancelled");
+  });
+
+  it("returns an error when accept is missing content", async () => {
+    const { client } = await setupClientServer(async () => ({
+      action: "accept",
+    }));
+
+    const result = await client.callTool({
+      name: "elicit_echo",
+      arguments: {},
+    });
+
+    const parsed = parseContent(result);
+    expect(parsed.error).toBe("Accepted but no content was returned");
+  });
+
+  it("returns an error when the client does not support elicitation", async () => {
+    const { client } = await setupClientServerWithoutElicitation();
+
+    const result = await client.callTool({
+      name: "elicit_echo",
+      arguments: {},
+    });
+
+    const parsed = parseContent(result);
+    expect(parsed.error).toMatch(/elicitation/i);
+  });
+});

--- a/src/tools.test.ts
+++ b/src/tools.test.ts
@@ -1,13 +1,27 @@
 import { afterEach, describe, it, expect } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { CallToolResultSchema, ElicitRequestSchema, type ElicitResult } from "@modelcontextprotocol/sdk/types.js";
+import {
+  CallToolResultSchema,
+  ElicitRequestSchema,
+  LoggingMessageNotificationSchema,
+  type ElicitResult,
+} from "@modelcontextprotocol/sdk/types.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerTools } from "./tools.ts";
 
 type TestHarness = {
   client: Client;
   server: McpServer;
+};
+
+type SetupOptions = {
+  /** Handles elicitation requests. If omitted, the client won't respond to them. */
+  elicitHandler?: (request: { message: string }) => Promise<ElicitResult>;
+  /** Whether the client advertises elicitation support. Defaults to true. */
+  supportsElicitation?: boolean;
+  /** Collects any logging notifications the server sends to the client. */
+  onLog?: (params: { level: string; data: unknown; logger?: string }) => void;
 };
 
 let harness: TestHarness | undefined;
@@ -21,13 +35,15 @@ afterEach(async () => {
 });
 
 /**
- * Wires up an in-memory client/server pair for integration testing.
- * When an elicitHandler is provided, the client advertises elicitation
- * support and routes elicitation requests to it. When omitted, the
- * client still advertises elicitation support (so non-elicitation tools
- * can be tested) but does not handle elicitation requests.
+ * Wires up an in-memory client/server pair for integration testing, exercising
+ * the full MCP protocol stack in-process. A single helper covers every case:
+ *   - pass an `elicitHandler` to answer elicitation requests
+ *   - set `supportsElicitation: false` to test the unsupported-client path
+ *   - pass `onLog` to capture outbound logging notifications
  */
-async function setupClientServer(elicitHandler?: (request: { message: string }) => Promise<ElicitResult>) {
+async function setupClientServer(options: SetupOptions = {}) {
+  const { elicitHandler, supportsElicitation = true, onLog } = options;
+
   const server = new McpServer(
     { name: "test-server", version: "0.0.0" },
     { capabilities: { logging: {} } },
@@ -38,7 +54,7 @@ async function setupClientServer(elicitHandler?: (request: { message: string }) 
 
   const client = new Client(
     { name: "test-client", version: "0.0.0" },
-    { capabilities: { elicitation: {} } },
+    { capabilities: supportsElicitation ? { elicitation: {} } : {} },
   );
 
   if (elicitHandler) {
@@ -47,30 +63,11 @@ async function setupClientServer(elicitHandler?: (request: { message: string }) 
     });
   }
 
-  await server.connect(serverTransport);
-  await client.connect(clientTransport);
-
-  harness = { client, server };
-  return harness;
-}
-
-/**
- * Like setupClientServer but the client does NOT advertise elicitation
- * support, so server.server.elicitInput() will throw.
- */
-async function setupClientServerWithoutElicitation() {
-  const server = new McpServer(
-    { name: "test-server", version: "0.0.0" },
-    { capabilities: { logging: {} } },
-  );
-  registerTools(server);
-
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-
-  const client = new Client(
-    { name: "test-client", version: "0.0.0" },
-    { capabilities: {} },
-  );
+  if (onLog) {
+    client.setNotificationHandler(LoggingMessageNotificationSchema, (notification) => {
+      onLog(notification.params);
+    });
+  }
 
   await server.connect(serverTransport);
   await client.connect(clientTransport);
@@ -104,15 +101,34 @@ describe("echo tool", () => {
 
     const parsed = parseContent(result);
     expect(parsed.echo).toBe("hello");
+    // Success results also carry structuredContent for outputSchema-aware clients.
+    expect(result.structuredContent).toEqual({ echo: "hello" });
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("sends an MCP log notification to the client", async () => {
+    const logs: Array<{ level: string; data: unknown; logger?: string }> = [];
+    const { client } = await setupClientServer({ onLog: (params) => logs.push(params) });
+
+    // Ask to receive debug-level notifications, then invoke the tool.
+    await client.setLoggingLevel("debug");
+    await client.callTool({ name: "echo", arguments: { message: "hi" } });
+
+    const echoLog = logs.find((l) => l.logger === "echo");
+    expect(echoLog).toBeDefined();
+    expect(echoLog?.level).toBe("debug");
+    expect(echoLog?.data).toEqual({ message: "hi" });
   });
 });
 
 describe("elicit_echo tool", () => {
   it("echoes the message the user provides via elicitation", async () => {
-    const { client } = await setupClientServer(async () => ({
-      action: "accept",
-      content: { message: "elicited hello" },
-    }));
+    const { client } = await setupClientServer({
+      elicitHandler: async () => ({
+        action: "accept",
+        content: { message: "elicited hello" },
+      }),
+    });
 
     const result = await client.callTool({
       name: "elicit_echo",
@@ -121,12 +137,14 @@ describe("elicit_echo tool", () => {
 
     const parsed = parseContent(result);
     expect(parsed.echo).toBe("elicited hello");
+    expect(result.structuredContent).toEqual({ echo: "elicited hello" });
+    expect(result.isError).toBeFalsy();
   });
 
-  it("returns a decline response when the user declines", async () => {
-    const { client } = await setupClientServer(async () => ({
-      action: "decline",
-    }));
+  it("returns a decline response (not an error) when the user declines", async () => {
+    const { client } = await setupClientServer({
+      elicitHandler: async () => ({ action: "decline" }),
+    });
 
     const result = await client.callTool({
       name: "elicit_echo",
@@ -136,12 +154,14 @@ describe("elicit_echo tool", () => {
     const parsed = parseContent(result);
     expect(parsed.echo).toBeNull();
     expect(parsed.reason).toBe("User declined to provide a message");
+    // A decline is a valid outcome, not a failure.
+    expect(result.isError).toBeFalsy();
   });
 
-  it("returns a cancel response when the user cancels", async () => {
-    const { client } = await setupClientServer(async () => ({
-      action: "cancel",
-    }));
+  it("returns a cancel response (not an error) when the user cancels", async () => {
+    const { client } = await setupClientServer({
+      elicitHandler: async () => ({ action: "cancel" }),
+    });
 
     const result = await client.callTool({
       name: "elicit_echo",
@@ -151,12 +171,13 @@ describe("elicit_echo tool", () => {
     const parsed = parseContent(result);
     expect(parsed.echo).toBeNull();
     expect(parsed.reason).toBe("Elicitation was cancelled");
+    expect(result.isError).toBeFalsy();
   });
 
-  it("returns an error when accept is missing content", async () => {
-    const { client } = await setupClientServer(async () => ({
-      action: "accept",
-    }));
+  it("returns an error result when accept is missing content", async () => {
+    const { client } = await setupClientServer({
+      elicitHandler: async () => ({ action: "accept" }),
+    });
 
     const result = await client.callTool({
       name: "elicit_echo",
@@ -165,10 +186,11 @@ describe("elicit_echo tool", () => {
 
     const parsed = parseContent(result);
     expect(parsed.error).toBe("Accepted but no content was returned");
+    expect(result.isError).toBe(true);
   });
 
-  it("returns an error when the client does not support elicitation", async () => {
-    const { client } = await setupClientServerWithoutElicitation();
+  it("returns an error result when the client does not support elicitation", async () => {
+    const { client } = await setupClientServer({ supportsElicitation: false });
 
     const result = await client.callTool({
       name: "elicit_echo",
@@ -177,5 +199,6 @@ describe("elicit_echo tool", () => {
 
     const parsed = parseContent(result);
     expect(parsed.error).toMatch(/elicitation/i);
+    expect(result.isError).toBe(true);
   });
 });

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,0 +1,126 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult, ElicitRequestFormParams, ElicitResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { createTextResult } from "./lib/utils.ts";
+import { logger } from "./logger.ts";
+
+type ElicitInputFn = (params: ElicitRequestFormParams) => Promise<ElicitResult>;
+type SendLoggingMessageFn = (params: {
+  level: "debug" | "info" | "notice" | "warning" | "error" | "critical" | "alert" | "emergency";
+  data: unknown;
+  logger?: string;
+}) => Promise<void>;
+
+/**
+ * Registers all MCP tools on the server.
+ * Called once per session from getServer() in src/index.ts.
+ */
+export function registerTools(server: McpServer): void {
+  server.registerTool(
+    "elicit_echo",
+    {
+      title: "Elicit Echo",
+      description: "Ask the user what they want to echo back, then echoes it",
+    },
+    (extra) => elicitEcho(server.server.elicitInput.bind(server.server), extra),
+  );
+
+  server.registerTool(
+    "echo",
+    {
+      title: "Echo",
+      description: "Echo back the provided message",
+      inputSchema: {
+        message: z.string().describe("The message to echo back"),
+      },
+    },
+    (args, extra) => echo(server.sendLoggingMessage.bind(server), args, extra),
+  );
+}
+
+/**
+ * Asks the user what they want to echo via MCP elicitation, then echoes it back.
+ * Handles all three elicitation outcomes: accept, decline, and cancel.
+ */
+async function elicitEcho(
+  elicitInput: ElicitInputFn,
+  extra: { sessionId?: string; requestId: unknown },
+): Promise<CallToolResult> {
+  const toolName = "elicit_echo";
+  const { sessionId, requestId } = extra;
+  try {
+    const result = await elicitInput({
+      message: "What would you like to echo?",
+      requestedSchema: {
+        type: "object",
+        properties: {
+          message: {
+            type: "string",
+            title: "Message",
+            description: "The message to echo back",
+          },
+        },
+        required: ["message"],
+      },
+    });
+
+    if (result.action === "accept") {
+      if (!result.content) {
+        logger.warn({ toolName, sessionId, requestId }, "Accept response missing content");
+        return createTextResult({ error: "Accepted but no content was returned" });
+      }
+      const data = { echo: result.content.message };
+      logger.info({ toolName, sessionId, requestId }, "Tool executed");
+      return createTextResult(data);
+    }
+
+    if (result.action === "decline") {
+      logger.info({ toolName, sessionId, requestId, action: "decline" }, "User declined elicitation");
+      return createTextResult({ echo: null, reason: "User declined to provide a message" });
+    }
+
+    logger.info({ toolName, sessionId, requestId, action: "cancel" }, "User cancelled elicitation");
+    return createTextResult({ echo: null, reason: "Elicitation was cancelled" });
+  } catch (error) {
+    logger.error(
+      { toolName, sessionId, requestId, error: error instanceof Error ? error.message : String(error) },
+      "Tool execution failed",
+    );
+    return createTextResult({
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
+ * Echoes back the provided message. Also sends a debug log notification
+ * to the client as a demonstration of MCP logging.
+ */
+async function echo(
+  sendLoggingMessage: SendLoggingMessageFn,
+  args: { message: string },
+  extra: { sessionId?: string; requestId: unknown },
+): Promise<CallToolResult> {
+  const toolName = "echo";
+  const { sessionId, requestId } = extra;
+  // Example: send an MCP log notification to the client. The client
+  // controls which levels it receives via logging/setLevel.
+  // See: https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/logging
+  try {
+    await sendLoggingMessage({
+      level: "debug",
+      data: { message: args.message },
+      logger: "echo",
+    });
+  } catch (error) {
+    // Log notification failures must not prevent the tool from responding.
+    logger.debug(
+      { error: error instanceof Error ? error.message : String(error) },
+      "Failed to send MCP log notification",
+    );
+  }
+
+  const data = { echo: args.message };
+  logger.info({ toolName, sessionId, requestId }, "Tool executed");
+  return createTextResult(data);
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult, ElicitRequestFormParams, ElicitResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { createTextResult } from "./lib/utils.ts";
+import { createErrorResult, createTextResult } from "./lib/utils.ts";
 import { logger } from "./logger.ts";
 
 type ElicitInputFn = (params: ElicitRequestFormParams) => Promise<ElicitResult>;
@@ -21,6 +21,22 @@ export function registerTools(server: McpServer): void {
     {
       title: "Elicit Echo",
       description: "Ask the user what they want to echo back, then echoes it",
+      // `outputSchema` lets clients validate and consume `structuredContent`
+      // (see createTextResult). The echo may be null when the user declines or
+      // cancels, so `echo` is nullable and not required.
+      // https://modelcontextprotocol.io/specification/2025-06-18/server/tools#output-schema
+      outputSchema: {
+        echo: z.string().nullable().describe("The echoed message, or null if none was provided"),
+        reason: z.string().optional().describe("Why no message was echoed, when applicable"),
+      },
+      // Annotations are untrusted hints clients use for UX/safety. This tool
+      // neither mutates state nor touches the outside world.
+      // https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool
+      annotations: {
+        readOnlyHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
     (extra) => elicitEcho(server.server.elicitInput.bind(server.server), extra),
   );
@@ -30,8 +46,20 @@ export function registerTools(server: McpServer): void {
     {
       title: "Echo",
       description: "Echo back the provided message",
+      // Tool *input* is declared with a Zod schema — the SDK compiles it to
+      // JSON Schema and validates incoming args for us. (Contrast with the
+      // elicitation `requestedSchema` in elicitEcho, which must be hand-written
+      // JSON Schema; see the comment there.)
       inputSchema: {
         message: z.string().describe("The message to echo back"),
+      },
+      outputSchema: {
+        echo: z.string().describe("The echoed message"),
+      },
+      annotations: {
+        readOnlyHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
       },
     },
     (args, extra) => echo(server.sendLoggingMessage.bind(server), args, extra),
@@ -49,6 +77,12 @@ async function elicitEcho(
   const toolName = "elicit_echo";
   const { sessionId, requestId } = extra;
   try {
+    // Elicitation `requestedSchema` must be a hand-written, flat JSON Schema
+    // (the restricted subset the MCP spec allows: primitive properties only,
+    // no nesting). This is why we don't reuse a Zod schema here the way `echo`
+    // does for its inputSchema — elicitation intentionally accepts only this
+    // limited shape so clients can render a simple form.
+    // https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation#request-schema
     const result = await elicitInput({
       message: "What would you like to echo?",
       requestedSchema: {
@@ -67,13 +101,16 @@ async function elicitEcho(
     if (result.action === "accept") {
       if (!result.content) {
         logger.warn({ toolName, sessionId, requestId }, "Accept response missing content");
-        return createTextResult({ error: "Accepted but no content was returned" });
+        // A genuine failure: the client claimed acceptance but sent nothing.
+        return createErrorResult({ error: "Accepted but no content was returned" });
       }
       const data = { echo: result.content.message };
       logger.info({ toolName, sessionId, requestId }, "Tool executed");
       return createTextResult(data);
     }
 
+    // Decline and cancel are valid user outcomes, not errors — return them as
+    // normal results (no isError) so the model treats them as a real answer.
     if (result.action === "decline") {
       logger.info({ toolName, sessionId, requestId, action: "decline" }, "User declined elicitation");
       return createTextResult({ echo: null, reason: "User declined to provide a message" });
@@ -82,11 +119,13 @@ async function elicitEcho(
     logger.info({ toolName, sessionId, requestId, action: "cancel" }, "User cancelled elicitation");
     return createTextResult({ echo: null, reason: "Elicitation was cancelled" });
   } catch (error) {
+    // Reaching here means elicitation itself failed (e.g. the client doesn't
+    // support it) — a genuine execution error.
     logger.error(
       { toolName, sessionId, requestId, error: error instanceof Error ? error.message : String(error) },
       "Tool execution failed",
     );
-    return createTextResult({
+    return createErrorResult({
       error: error instanceof Error ? error.message : String(error),
     });
   }


### PR DESCRIPTION
## Summary

Adds an elicit_echo tool that uses elicitation/create to ask the user
what they want to echo rather than accepting it as a direct argument.
Demonstrates form-based elicitation (SEP-1034) via the high-level
server.server.elicitInput() API.

Also adds sessionId and requestId to pino log output for both elicit_echo
and echo, consistent with the project logging guidelines.

Generated with [Devin](https://devin.ai)

Elicitation in action in GitHub Copilot in VS Code Insiders

https://github.com/user-attachments/assets/d380b269-3bf6-4be7-be84-5b092b001f4e

## Related Issues

Closes #74

## AI Disclosure

Co-Authored-By: Devin <158243242+devin-ai-integration[bot]@users.noreply.github.com>. I reviewed the code and added some suggestions like logging the session and request IDs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two MCP tools, including an elicitation-driven echo flow and improved structured outputs.
  * Tool responses now include richer, schema-aligned data for better client handling.

* **Bug Fixes**
  * Improved error reporting so failed tool runs return clearer in-band errors.
  * Refined handling for declined or canceled elicitation responses.

* **Documentation**
  * Updated setup and contribution guidance to match the latest project structure and testing approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->