### PR TITLE
feat!: migrate to MCP 2026-07-28 stateless spec

### DIFF
--- a/.agents/skills/create-mcp-tool/SKILL.md
+++ b/.agents/skills/create-mcp-tool/SKILL.md
@@ -81,7 +81,8 @@ Key points:
 - `inputSchema` / `outputSchema` must be a `z.object({...})` — the bare `{ field: z.string() }` shorthand is deprecated
 - Return `createTextResult(data)` on success — it emits both a text block and `structuredContent` for `outputSchema`-aware clients ([structured content](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content))
 - Keep the tool's logic in a function that receives only the dependencies it needs (e.g. `sendLoggingMessage`, `ctx`); pass them from the registration callback with `.bind()` where needed. This keeps each tool small and testable
-- Log tool execution with `logger.info` and failures with `logger.error`, including `requestId` (`ctx.mcpReq.id`) for traceability — there's no `sessionId` under the stateless spec
+- Log tool execution with `logger.info` and failures with `logger.error`, always including `toolName` and `requestId` (`ctx.mcpReq.id`) for correlation — there's no `sessionId` under the stateless spec
+- Never log the raw `args` object — tool inputs may carry user-provided or sensitive data. Log individual fields only when they're known to be safe (see `action`/`kind` in `elicitEcho`'s error/decline/cancel logs in `src/tools.ts`)
 
 ### Tool Annotations
 

--- a/.agents/skills/create-mcp-tool/SKILL.md
+++ b/.agents/skills/create-mcp-tool/SKILL.md
@@ -8,7 +8,7 @@ metadata:
 
 # Add an MCP Tool to This Template
 
-This skill walks you through adding a new tool to the MCP server. If you need to reference MCP SDK types, capabilities, or advanced patterns not covered here, use the context7 MCP server or WebFetch to look up the [`@modelcontextprotocol/sdk` documentation](https://github.com/modelcontextprotocol/typescript-sdk).
+This skill walks you through adding a new tool to the MCP server. If you need to reference MCP SDK types, capabilities, or advanced patterns not covered here, use the context7 MCP server or WebFetch to look up the [`@modelcontextprotocol/server` documentation](https://github.com/modelcontextprotocol/typescript-sdk).
 
 ---
 
@@ -23,7 +23,7 @@ This skill walks you through adding a new tool to the MCP server. If you need to
 | Typed output | `outputSchema` + `structuredContent` (emitted automatically by `createTextResult`) |
 | Tests | `src/tools.test.ts` (colocated with `src/tools.ts`) |
 
-Everything for a tool lives in `src/tools.ts`. `registerTools(server)` is the single source of truth for tool wiring — it's called from `getServer()` in `src/index.ts` **and** reused by the tests, so registration can never drift from what's tested. Each tool's implementation is a function that takes only the dependencies it needs (e.g. the bound `elicitInput` function, `sendLoggingMessage`, and the `extra` object), which keeps it small and easy to drive through every branch. `index.ts` owns only HTTP routing and session lifecycle; each session gets its own isolated `McpServer` instance.
+Everything for a tool lives in `src/tools.ts`. `registerTools(server)` is the single source of truth for tool wiring — it's called from `getServer()` in `src/index.ts` **and** reused by the tests, so registration can never drift from what's tested. Each tool's implementation is a function that takes only the dependencies it needs (e.g. the bound `sendLoggingMessage` function and the `ctx` object), which keeps it small and easy to drive through every branch. `index.ts` owns only HTTP routing via `createMcpHandler` — per the MCP 2026-07-28 spec there's no session: `getServer()` runs fresh for every request.
 
 ---
 
@@ -45,19 +45,19 @@ server.registerTool(
   {
     title: "My Tool",
     description: "A clear, specific description of what this tool does and when to use it",
-    inputSchema: {
+    inputSchema: z.object({
       query: z.string().describe("The input to process — be specific about format or constraints"),
       limit: z.number().int().min(1).max(100).optional().describe("Maximum number of results to return (default: 10)"),
-    },
+    }),
     // Declare the shape of a successful result so clients can consume
     // structuredContent (createTextResult emits it automatically).
-    outputSchema: {
+    outputSchema: z.object({
       output: z.string().describe("The processed output"),
       count: z.number().describe("Number of results"),
-    },
+    }),
     annotations: { readOnlyHint: true, openWorldHint: false },
   },
-  (args, extra) => myTool(args, extra),
+  (args, ctx) => myTool(args, ctx),
 );
 ```
 
@@ -66,22 +66,22 @@ Then implement `myTool` as a function lower in the file:
 ```typescript
 async function myTool(
   args: { query: string; limit?: number },
-  extra: { sessionId?: string; requestId: unknown },
+  ctx: ServerContext,
 ): Promise<CallToolResult> {
   const toolName = "my_tool";
-  const { sessionId, requestId } = extra;
+  const requestId = ctx.mcpReq.id;
 
   const result = { output: args.query, count: 1 };
-  logger.info({ toolName, sessionId, requestId }, "Tool executed");
+  logger.info({ toolName, requestId }, "Tool executed");
   return createTextResult(result);
 }
 ```
 
 Key points:
-- `inputSchema` / `outputSchema` take an object of Zod field definitions (not a full `z.object()` — just the shape)
+- `inputSchema` / `outputSchema` must be a `z.object({...})` — the bare `{ field: z.string() }` shorthand is deprecated
 - Return `createTextResult(data)` on success — it emits both a text block and `structuredContent` for `outputSchema`-aware clients ([structured content](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content))
-- Keep the tool's logic in a function that receives only the dependencies it needs (e.g. `elicitInput`, `sendLoggingMessage`, `extra`); pass them from the registration callback with `.bind()` where needed. This keeps each tool small and testable
-- Log tool execution with `logger.info` and failures with `logger.error`, including `sessionId` and `requestId` from `extra` for traceability
+- Keep the tool's logic in a function that receives only the dependencies it needs (e.g. `sendLoggingMessage`, `ctx`); pass them from the registration callback with `.bind()` where needed. This keeps each tool small and testable
+- Log tool execution with `logger.info` and failures with `logger.error`, including `requestId` (`ctx.mcpReq.id`) for traceability — there's no `sessionId` under the stateless spec
 
 ### Tool Annotations
 
@@ -117,17 +117,17 @@ server.registerTool(
 Report execution failures in-band with `createErrorResult` (which sets `isError: true`) rather than throwing — this lets the client/model distinguish a failure from a normal result. Reserve `isError` for genuine failures; valid outcomes (e.g. a user declining an elicitation, or an empty search) are normal results via `createTextResult`. See [Error Handling](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#error-handling) in the spec.
 
 ```typescript
-async function myTool(args, extra) {
+async function myTool(args, ctx) {
   const toolName = "my_tool";
-  const { sessionId, requestId } = extra;
+  const requestId = ctx.mcpReq.id;
 
   try {
     const result = await doSomething(args.query);
-    logger.info({ toolName, sessionId, requestId }, "Tool executed");
+    logger.info({ toolName, requestId }, "Tool executed");
     return createTextResult(result);
   } catch (error) {
     logger.error(
-      { toolName, sessionId, requestId, error: error instanceof Error ? error.message : String(error) },
+      { toolName, requestId, error: error instanceof Error ? error.message : String(error) },
       "Tool execution failed",
     );
     return createErrorResult({
@@ -136,6 +136,38 @@ async function myTool(args, extra) {
   }
 }
 ```
+
+### Needing user input mid-call
+
+If a tool must ask the user something before it can finish (the `elicit_echo` pattern), don't use the old synchronous `elicitInput()` push request — it throws on a 2026-07-28-era connection. Instead return an `inputRequired()` result and read the response back via `inputResponse()`/`ctx.mcpReq.inputResponses` on the retried call:
+
+```typescript
+import { inputRequired, inputResponse } from "@modelcontextprotocol/server";
+
+function myTool(ctx: ServerContext): CallToolResult | InputRequiredResult {
+  const response = inputResponse(ctx.mcpReq.inputResponses, "confirm");
+
+  if (response.kind === "missing") {
+    return inputRequired({
+      inputRequests: {
+        confirm: inputRequired.elicit({
+          message: "Proceed?",
+          requestedSchema: {
+            type: "object",
+            properties: { confirm: { type: "boolean" } },
+            required: ["confirm"],
+          },
+        }),
+      },
+    });
+  }
+
+  // response.kind === "elicit" here; handle response.action (accept/decline/cancel)
+  // ...
+}
+```
+
+The client resolves the embedded request and retries the same tool call with the response attached — this handler runs again, on a fresh request id, and sees it via `ctx.mcpReq.inputResponses`. See `elicitEcho` in `src/tools.ts` for a complete worked example, including decline/cancel handling.
 
 ---
 
@@ -147,10 +179,8 @@ Follow the existing pattern:
 
 ```typescript
 import { afterEach, describe, it, expect } from "vitest";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/client";
+import { McpServer, InMemoryTransport, type CallToolResult } from "@modelcontextprotocol/server";
 import { registerTools } from "./tools.ts";
 
 let harness: { client: Client; server: McpServer } | undefined;
@@ -183,15 +213,10 @@ async function setupClientServer() {
   return harness;
 }
 
-function parseContent(result: unknown): Record<string, unknown> {
-  const parsed = CallToolResultSchema.safeParse(result);
-  expect(parsed.success).toBe(true);
-  if (!parsed.success) {
-    throw new Error("callTool result did not match CallToolResult schema");
-  }
-  const item = parsed.data.content[0];
-  expect(item.type).toBe("text");
-  if (item.type !== "text") {
+function parseContent(result: CallToolResult): Record<string, unknown> {
+  const item = result.content[0];
+  expect(item?.type).toBe("text");
+  if (item?.type !== "text") {
     throw new Error("expected text content");
   }
   return JSON.parse(item.text);
@@ -217,7 +242,7 @@ Key points:
 - Connect the server before the client (`server.connect` then `client.connect`) so the initialize handshake completes
 - Use `afterEach` to close both sides leak-safely, even if assertions fail
 - The existing `setupClientServer` takes an options object — pass `elicitHandler` to answer elicitation, `supportsElicitation: false` to test the unsupported-client path, and `onLog` to capture outbound logging notifications. Reuse it rather than adding new helpers
-- Use `CallToolResultSchema.safeParse()` to validate and narrow the `callTool` return type before asserting on content
+- `client.callTool()` already returns a typed `CallToolResult` — no schema re-validation needed, just narrow `content[0].type === "text"` before parsing it
 - Assert `result.structuredContent` for `outputSchema`-aware output, and `result.isError` to confirm failures are flagged (and that valid outcomes are *not*)
 
 Run tests with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,10 +96,10 @@ Use `logger` from `src/logger.ts` — **never `console.log`**.
 ```ts
 // Structured data first, message second
 logger.info({ requestId, toolName }, "Tool executed");
-logger.error({ error: error.message, toolName }, "Tool execution failed");
+logger.error({ requestId, toolName, error: error.message }, "Tool execution failed");
 ```
 
-Log levels: `error` > `warn` > `info` > `debug`. Include relevant IDs (request, user, tool). Pino automatically correlates traces when OpenTelemetry is configured.
+Log levels: `error` > `warn` > `info` > `debug`. Include `requestId` and `toolName` on every entry so log lines can be correlated back to a single call; add other scalar fields relevant to the outcome (e.g. `action`, `kind`). Never log the raw `args` object — tool inputs may carry user-provided or sensitive data — log individual fields only when they're known to be safe to record. Pino automatically correlates traces when OpenTelemetry is configured.
 
 ## Adding a New Tool
 
@@ -110,8 +110,8 @@ See the `create-mcp-tool` skill (`.agents/skills/create-mcp-tool`) for the full 
 3. The handler receives `(args, ctx)` (or just `(ctx)` with no `inputSchema`) — `ctx.mcpReq.id` is the request id; there is no `sessionId` to rely on
 4. Return `createTextResult(result)` on success (it also emits `structuredContent`)
 5. On genuine failure return `createErrorResult({ error })` (sets `isError: true`); don't throw
-6. Log with `logger.info({ toolName, args }, "Tool executed")` on success
-7. Log with `logger.error({ toolName, error: error.message }, "Tool execution failed")` on failure
+6. Log with `logger.info({ toolName, requestId }, "Tool executed")` on success
+7. Log with `logger.error({ toolName, requestId, error: error.message }, "Tool execution failed")` on failure — omit the raw `args` object (see Logging)
 8. If the tool needs user input mid-call, return `inputRequired({ inputRequests: {...} })` (see `elicit_echo` in `src/tools.ts`) — the older synchronous `elicitInput()` push request throws on a 2026-07-28-era connection
 9. Add integration tests to `src/tools.test.ts` (import `registerTools`, wire an in-memory client/server)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ npm run lint && npm run format:check && npm run build && npm run test:ci
 
 ```
 src/
-  index.ts       # HTTP routing, session lifecycle; calls registerTools() in getServer()
+  index.ts       # HTTP routing via createMcpHandler + toNodeHandler (stateless, per-request); calls registerTools() in getServer()
   tools.ts       # registerTools() wiring + per-tool logic functions
   tools.test.ts  # colocated integration tests (in-memory client/server)
   config.ts      # Env var validation via Zod
@@ -56,12 +56,14 @@ Config files (`vite.config.ts`, `tsconfig.json`, `eslint.config.js`, `Dockerfile
 - Tools registered via `registerTools(server)` in `src/tools.ts`, the single source of truth for tool wiring — called from `getServer()` in `src/index.ts` and reused by the tests
 - Tool responses use `createTextResult` / `createErrorResult` from `src/lib/utils.ts`: a text `content` block plus `structuredContent` (for clients that declare an `outputSchema`)
 - Genuine execution failures return `isError: true` (via `createErrorResult`), not thrown; valid outcomes (e.g. a user declining an elicitation) are normal results
-- Session lifecycle managed via `StreamableHTTPServerTransport`
-- Graceful shutdown on `SIGTERM`/`SIGINT`
+- Stateless per the MCP 2026-07-28 spec: no `initialize`/`initialized` handshake, no `Mcp-Session-Id` — `createMcpHandler`'s factory runs `getServer()` fresh for every HTTP request. It also serves older (2025-era) clients automatically via a stateless fallback, so no separate legacy transport is needed.
+- `GET /health` is a plain liveness endpoint (used by the Docker healthcheck) — `GET /mcp` itself is routed to the MCP handler and no longer doubles as one
+- If a tool needs state across calls, mint an explicit handle and have the model pass it back as an argument on the next call — there is no transport-level session to hang state off anymore
+- Graceful shutdown on `SIGTERM`/`SIGINT` (closes the handler, then exits)
 
 ### Build System
 
-- Vite bundles to ES modules; `@modelcontextprotocol/sdk` is external (not bundled)
+- Vite bundles to ES modules; `@modelcontextprotocol/server` and `@modelcontextprotocol/node` are external (not bundled)
 - `@` path alias maps to `src/`
 - Node.js 24+ required (native TypeScript type stripping used in dev)
 
@@ -93,23 +95,25 @@ Use `logger` from `src/logger.ts` — **never `console.log`**.
 
 ```ts
 // Structured data first, message second
-logger.info({ sessionId, toolName }, "Tool executed");
+logger.info({ requestId, toolName }, "Tool executed");
 logger.error({ error: error.message, toolName }, "Tool execution failed");
 ```
 
-Log levels: `error` > `warn` > `info` > `debug`. Include relevant IDs (session, user, tool). Pino automatically correlates traces when OpenTelemetry is configured.
+Log levels: `error` > `warn` > `info` > `debug`. Include relevant IDs (request, user, tool). Pino automatically correlates traces when OpenTelemetry is configured.
 
 ## Adding a New Tool
 
 See the `create-mcp-tool` skill (`.agents/skills/create-mcp-tool`) for the full walkthrough. In short:
 
 1. Add the `server.registerTool()` call inside `registerTools()` in `src/tools.ts`
-2. Provide a `title`, `description`, Zod `inputSchema`, an `outputSchema`, and `annotations` (e.g. `readOnlyHint`)
-3. Return `createTextResult(result)` on success (it also emits `structuredContent`)
-4. On genuine failure return `createErrorResult({ error })` (sets `isError: true`); don't throw
-5. Log with `logger.info({ toolName, args }, "Tool executed")` on success
-6. Log with `logger.error({ toolName, error: error.message }, "Tool execution failed")` on failure
-7. Add integration tests to `src/tools.test.ts` (import `registerTools`, wire an in-memory client/server)
+2. Provide a `title`, `description`, `inputSchema`/`outputSchema` wrapped in `z.object({...})` (the raw-shape `{ field: z.string() }` form is deprecated), and `annotations` (e.g. `readOnlyHint`)
+3. The handler receives `(args, ctx)` (or just `(ctx)` with no `inputSchema`) — `ctx.mcpReq.id` is the request id; there is no `sessionId` to rely on
+4. Return `createTextResult(result)` on success (it also emits `structuredContent`)
+5. On genuine failure return `createErrorResult({ error })` (sets `isError: true`); don't throw
+6. Log with `logger.info({ toolName, args }, "Tool executed")` on success
+7. Log with `logger.error({ toolName, error: error.message }, "Tool execution failed")` on failure
+8. If the tool needs user input mid-call, return `inputRequired({ inputRequests: {...} })` (see `elicit_echo` in `src/tools.ts`) — the older synchronous `elicitInput()` push request throws on a 2026-07-28-era connection
+9. Add integration tests to `src/tools.test.ts` (import `registerTools`, wire an in-memory client/server)
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ This template follows a simple architecture:
 - **Stateless** - Per the MCP 2026-07-28 spec: no `initialize`/`initialized` handshake, no session ID — `getServer()` runs fresh for every HTTP request. Older (2025-era) clients are still served automatically via a built-in stateless fallback
 - **Tool Registration** - `registerTools(server)` in `src/tools.ts` is the single source of truth for tool wiring; `getServer()` and the tests both use it
 - **Typed I/O** - Zod `inputSchema`/`outputSchema` (wrapped in `z.object()`) for validation, plus `structuredContent` for typed results
-- **Error Handling** - Genuine failures return `isError: true` via `createErrorResult`; results are never thrown
+- **Error Handling** - Genuine tool execution failures return `isError: true` via `createErrorResult` rather than being thrown; protocol, transport, and capability failures (e.g. an unsupported elicitation) can still reject the client call
 - **Health Check** - `GET /health` is a plain liveness endpoint (used by the Docker health check); `GET /mcp` is routed to the MCP handler itself
 
 ## Example: Adding a New Tool

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ This template follows a simple architecture:
 Add the registration inside `registerTools()` in `src/tools.ts`. See the `create-mcp-tool` skill (`.agents/skills/create-mcp-tool`) for the full walkthrough.
 
 ```typescript
+import { z } from "zod";
 import { createErrorResult, createTextResult } from "./lib/utils.ts";
 
 server.registerTool(

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ docker compose up --build
 ```
 mcp-typescript-template/
 ├── src/
-│   ├── index.ts          # HTTP routing + session lifecycle
+│   ├── index.ts          # HTTP routing via createMcpHandler (stateless, per-request)
 │   ├── tools.ts          # Tool registration (registerTools) and logic
 │   ├── tools.test.ts     # Integration tests (in-memory client/server)
 │   ├── config.ts         # Env var validation (Zod)
@@ -185,11 +185,12 @@ mcp-typescript-template/
 
 This template follows a simple architecture:
 
-- **HTTP Transport** - Uses Express with StreamableHTTPServerTransport for remote MCP connections
+- **HTTP Transport** - Uses Express with `createMcpHandler` (`@modelcontextprotocol/server`) for remote MCP connections
+- **Stateless** - Per the MCP 2026-07-28 spec: no `initialize`/`initialized` handshake, no session ID — `getServer()` runs fresh for every HTTP request. Older (2025-era) clients are still served automatically via a built-in stateless fallback
 - **Tool Registration** - `registerTools(server)` in `src/tools.ts` is the single source of truth for tool wiring; `getServer()` and the tests both use it
-- **Typed I/O** - Zod `inputSchema` for validation, plus `outputSchema` + `structuredContent` for typed results
+- **Typed I/O** - Zod `inputSchema`/`outputSchema` (wrapped in `z.object()`) for validation, plus `structuredContent` for typed results
 - **Error Handling** - Genuine failures return `isError: true` via `createErrorResult`; results are never thrown
-- **Session Management** - Handles MCP session initialization and management
+- **Health Check** - `GET /health` is a plain liveness endpoint (used by the Docker health check); `GET /mcp` is routed to the MCP handler itself
 
 ## Example: Adding a New Tool
 
@@ -203,13 +204,13 @@ server.registerTool(
   {
     title: "My Custom Tool",
     description: "Description of what this tool does",
-    inputSchema: {
+    inputSchema: z.object({
       param1: z.string().describe("Description of param1"),
       param2: z.number().optional().describe("Optional parameter"),
-    },
-    outputSchema: {
+    }),
+    outputSchema: z.object({
       output: z.string().describe("Description of the result"),
-    },
+    }),
     annotations: { readOnlyHint: true, openWorldHint: false },
   },
   async (args) => {
@@ -229,7 +230,7 @@ server.registerTool(
 
 This template uses Express for the HTTP server, which provides:
 
-- **MCP SDK Compatibility** - Full compatibility with the MCP TypeScript SDK's StreamableHTTPServerTransport
+- **MCP SDK Compatibility** - Full compatibility with `@modelcontextprotocol/server`'s `createMcpHandler`, adapted to Node/Express via `@modelcontextprotocol/node`'s `toNodeHandler`
 - **Mature & Stable** - Battle-tested HTTP server with extensive ecosystem
 - **TypeScript Support** - Excellent TypeScript support with comprehensive type definitions
 - **Middleware Ecosystem** - Rich ecosystem of middleware for common tasks

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
           "CMD",
           "node",
           "-e",
-          "require('http').get('http://localhost:3000/mcp', (r) => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"
+          "require('http').get('http://localhost:3000/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"
         ]
       interval: 2s
       timeout: 5s

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.26.0",
+        "@modelcontextprotocol/node": "^2.0.0",
+        "@modelcontextprotocol/server": "^2.0.0",
         "@types/express": "^5.0.6",
         "express": "^5.2.1",
         "pino": "^10.1.0",
@@ -18,6 +19,7 @@
       "devDependencies": {
         "@commitlint/cli": "^21.2.0",
         "@commitlint/config-conventional": "^21.2.0",
+        "@modelcontextprotocol/client": "^2.0.0",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "@types/node": "^22.19.1",
@@ -468,9 +470,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -566,9 +568,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -657,9 +659,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -741,44 +743,69 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
+        "@modelcontextprotocol/core": "2.0.0",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
         "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
+        "zod": "^4.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0.tgz",
+      "integrity": "sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
+        "@modelcontextprotocol/server": "^2.0.0",
+        "hono": "^4.11.4"
       },
       "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
+        "hono": {
           "optional": true
-        },
-        "zod": {
-          "optional": false
         }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -2589,6 +2616,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2599,23 +2627,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
       }
     },
     "node_modules/ansi-escapes": {
@@ -2772,16 +2783,16 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -3103,15 +3114,15 @@
       "license": "MIT"
     },
     "node_modules/concurrently": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.3.tgz",
-      "integrity": "sha512-ihjs0E2SxvDgq/MK418hX6YycQgKhsqxpbZuZbHo0yKfqDWdymWMjWYIpCIzqDDLLKClHlXev8whW/8WXmJ0BA==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.4.tgz",
+      "integrity": "sha512-TZ0CEhyzvFjgtAvHTusDMgj7wNdihCh7LLLrzdUOXIhdlnL2JBBGA9eJxR24rtqgmdjh3OA3hrN1rCHj6HM8qA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.8.4",
+        "shell-quote": "1.9.0",
         "supports-color": "8.1.1",
         "tree-kill": "1.2.2",
         "yargs": "17.7.2"
@@ -3373,23 +3384,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cors": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
-      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/cosmiconfig": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
@@ -3439,6 +3433,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4011,9 +4006,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4164,6 +4159,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eventsource-parser": "^3.0.1"
@@ -4176,6 +4172,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
       "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -4258,24 +4255,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^10.2.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
-      }
-    },
     "node_modules/fast-copy": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
@@ -4286,6 +4265,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -4309,9 +4289,10 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4832,6 +4813,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
       "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5049,15 +5031,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -5183,6 +5156,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/issue-parser": {
@@ -5226,6 +5200,7 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
       "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -5295,13 +5270,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -5982,9 +5952,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -6075,9 +6045,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.18.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.18.0.tgz",
-      "integrity": "sha512-T67M4L5wNm0cZ7EBLErcEkY1SmzEW/WJ+SADBzsFUY1UdAPfFHXFQtZ6SEXiK0+vzXysCvAsepbMaBTwnrAD+w==",
+      "version": "11.19.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.19.0.tgz",
+      "integrity": "sha512-SDd/hHg3KqHE5Ht2NHWxNYNtqCQ2pXAPLl6OtQhPyED5PHsRfrOtO199MZTIG2cQoQ1ZRI9t28shrD+2cr3AAw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -6156,7 +6126,7 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.9.0",
+        "@npmcli/arborist": "^9.9.1",
         "@npmcli/config": "^10.12.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
@@ -6181,11 +6151,11 @@
         "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.11",
-        "libnpmexec": "^10.3.1",
-        "libnpmfund": "^7.0.25",
+        "libnpmdiff": "^8.1.12",
+        "libnpmexec": "^10.3.2",
+        "libnpmfund": "^7.0.26",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.11",
+        "libnpmpack": "^9.1.12",
         "libnpmpublish": "^11.2.0",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
@@ -6286,7 +6256,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.9.0",
+      "version": "9.9.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7053,12 +7023,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.11",
+      "version": "8.1.12",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.9.0",
+        "@npmcli/arborist": "^9.9.1",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -7072,13 +7042,13 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.3.1",
+      "version": "10.3.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.9.0",
+        "@npmcli/arborist": "^9.9.1",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -7095,12 +7065,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.25",
+      "version": "7.0.26",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.9.0"
+        "@npmcli/arborist": "^9.9.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -7120,12 +7090,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.11",
+      "version": "9.1.12",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.9.0",
+        "@npmcli/arborist": "^9.9.1",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -7998,6 +7968,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8308,6 +8279,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8447,6 +8419,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
@@ -8530,9 +8503,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -8550,7 +8523,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8885,6 +8858,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8999,9 +8973,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/semantic-release": {
-      "version": "25.0.5",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.5.tgz",
-      "integrity": "sha512-mn61SUJwtM8ThrWn2WmgLVpwVJeG/hPSupua1psdMoufmwRIPyvRLkRkL0JDXkP67OntlLWUYnBnfVc8EDO3/g==",
+      "version": "25.0.8",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.8.tgz",
+      "integrity": "sha512-w/iZ0bur36rKffXZYmIUmy068eoBY3Ij1DCCddx2JwWEM5Tg+eU9ld/E9qSInVvPASyyR2Ln/XGfQ9OZrMlhtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9340,6 +9314,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -9352,15 +9327,16 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10542,6 +10518,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -10787,15 +10764,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@commitlint/cli": "^21.2.0",
     "@commitlint/config-conventional": "^21.2.0",
+    "@modelcontextprotocol/client": "^2.0.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@types/node": "^22.19.1",
@@ -47,7 +48,8 @@
     "vitest": "^4.1.9"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@modelcontextprotocol/node": "^2.0.0",
+    "@modelcontextprotocol/server": "^2.0.0",
     "@types/express": "^5.0.6",
     "express": "^5.2.1",
     "pino": "^10.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,6 @@
 import express from "express";
-import { randomUUID } from "node:crypto";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import { McpServer, createMcpHandler } from "@modelcontextprotocol/server";
+import { toNodeHandler } from "@modelcontextprotocol/node";
 import { logger } from "./logger.ts";
 import { getConfig } from "./config.ts";
 import { registerTools } from "./tools.ts";
@@ -26,105 +24,58 @@ const getServer = () => {
   return server;
 };
 
+// createMcpHandler runs the factory fresh per request (2026-07-28 spec: no
+// initialize/initialized handshake, no Mcp-Session-Id). It also answers
+// 2025-era stateful clients automatically via a stateless per-request
+// fallback, so no dual-transport wiring is needed for a transition period.
+const handler = createMcpHandler(getServer, {
+  onerror: (error) => {
+    logger.error({ error: error.message }, "Error handling MCP request");
+  },
+});
+
+const nodeHandler = toNodeHandler(handler, {
+  onerror: (error) => {
+    logger.error({ error: error.message }, "Error adapting MCP request for Node");
+  },
+});
+
 const app = express();
 app.use(express.json());
 
-const transports: { [sessionId: string]: StreamableHTTPServerTransport } = {};
+// There's no session to key a health check off anymore, so /mcp itself no
+// longer doubles as one (GET on it now goes through the MCP handler, not a
+// plain info response). Use a dedicated endpoint instead.
+app.get("/health", (_req, res) => {
+  const config = getConfig();
+  res.json({
+    name: config.SERVER_NAME,
+    version: config.SERVER_VERSION,
+    description: "TypeScript template for building MCP servers",
+    capabilities: ["tools"],
+  });
+});
 
-const mcpHandler = async (req: express.Request, res: express.Response) => {
-  const sessionId = req.headers["mcp-session-id"] as string | undefined;
-
-  try {
-    // Handle initialization requests (usually POST without session ID)
-    if (req.method === "POST" && !sessionId && isInitializeRequest(req.body)) {
-      logger.info("Initializing new MCP session");
-
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: () => randomUUID(),
-        onsessioninitialized: (sessionId) => {
-          transports[sessionId] = transport;
-          transport.onclose = () => {
-            delete transports[sessionId];
-            logger.info({ sessionId }, "MCP session closed");
-          };
-          logger.info({ sessionId }, "MCP session initialized");
-        },
-      });
-
-      const server = getServer();
-      await server.connect(transport);
-      await transport.handleRequest(req, res, req.body);
-      return;
-    }
-
-    // Handle existing session requests
-    if (sessionId && transports[sessionId]) {
-      const transport = transports[sessionId];
-      await transport.handleRequest(req, res, req.body);
-      return;
-    }
-
-    // Handle case where no session ID is provided for non-init requests
-    if (req.method === "POST" && !sessionId) {
-      logger.warn(
-        "POST request without session ID for non-initialization request",
-      );
-      res
-        .status(400)
-        .json({ error: "Session ID required for non-initialization requests" });
-      return;
-    }
-
-    // DELETE without a session ID is malformed
-    if (req.method === "DELETE" && !sessionId) {
-      logger.warn("DELETE request without session ID");
-      res.status(400).json({ error: "Session ID required to terminate a session" });
-      return;
-    }
-
-    // Handle unknown session
-    if (sessionId && !transports[sessionId]) {
-      logger.warn({ sessionId }, "Request for unknown session");
-      res.status(404).json({ error: "Session not found" });
-      return;
-    }
-
-    // For GET requests without session, return server info
-    if (req.method === "GET") {
-      const config = getConfig();
-      res.json({
-        name: config.SERVER_NAME,
-        version: config.SERVER_VERSION,
-        description: "TypeScript template for building MCP servers",
-        capabilities: ["tools"],
-      });
-    }
-  } catch (error) {
+app.all("/mcp", (req, res) => {
+  nodeHandler(req, res, req.body).catch((error) => {
     logger.error(
       { error: error instanceof Error ? error.message : String(error) },
-      "Error handling MCP request",
+      "Unhandled error serving MCP request",
     );
-    res.status(500).json({ error: "Internal server error" });
-  }
-};
-
-// Handle MCP requests on /mcp endpoint
-app.post("/mcp", mcpHandler);
-app.get("/mcp", mcpHandler);
-app.delete("/mcp", mcpHandler);
+  });
+});
 
 async function main() {
   const config = getConfig();
 
-  // Graceful shutdown handling
   process.on("SIGTERM", () => {
     logger.info("SIGTERM received, shutting down gracefully");
-    process.exit(0);
+    void handler.close().finally(() => process.exit(0));
   });
 
   process.on("SIGINT", () => {
     logger.info("SIGINT received, shutting down gracefully");
-    process.exit(0);
+    void handler.close().finally(() => process.exit(0));
   });
 
   app.listen(config.PORT, () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,10 @@ const handler = createMcpHandler(getServer, {
 
 const nodeHandler = toNodeHandler(handler, {
   onerror: (error) => {
-    logger.error({ error: error.message }, "Error adapting MCP request for Node");
+    logger.error(
+      { error: error.message },
+      "Error adapting MCP request for Node",
+    );
   },
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,17 +43,8 @@ const nodeHandler = toNodeHandler(handler, {
 const app = express();
 app.use(express.json());
 
-// There's no session to key a health check off anymore, so /mcp itself no
-// longer doubles as one (GET on it now goes through the MCP handler, not a
-// plain info response). Use a dedicated endpoint instead.
 app.get("/health", (_req, res) => {
-  const config = getConfig();
-  res.json({
-    name: config.SERVER_NAME,
-    version: config.SERVER_VERSION,
-    description: "TypeScript template for building MCP servers",
-    capabilities: ["tools"],
-  });
+  res.json({ status: "ok" });
 });
 
 app.all("/mcp", (req, res) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,15 @@ app.all("/mcp", (req, res) => {
       { error: error instanceof Error ? error.message : String(error) },
       "Unhandled error serving MCP request",
     );
+    if (!res.headersSent) {
+      res.status(500).json({
+        jsonrpc: "2.0",
+        error: { code: -32603, message: "Internal server error" },
+        id: null,
+      });
+    } else {
+      res.end();
+    }
   });
 });
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/server";
 
 /**
  * Creates a successful CallToolResult from any data.

--- a/src/tools.test.ts
+++ b/src/tools.test.ts
@@ -1,13 +1,13 @@
 import { afterEach, describe, it, expect } from "vitest";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { Client, StreamableHTTPClientTransport } from "@modelcontextprotocol/client";
 import {
-  CallToolResultSchema,
-  ElicitRequestSchema,
-  LoggingMessageNotificationSchema,
+  McpServer,
+  InMemoryTransport,
+  createMcpHandler,
+  type CallToolResult,
+  type ElicitRequest,
   type ElicitResult,
-} from "@modelcontextprotocol/sdk/types.js";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+} from "@modelcontextprotocol/server";
 import { registerTools } from "./tools.ts";
 
 type TestHarness = {
@@ -36,7 +36,16 @@ afterEach(async () => {
 
 /**
  * Wires up an in-memory client/server pair for integration testing, exercising
- * the full MCP protocol stack in-process. A single helper covers every case:
+ * the full MCP protocol stack in-process. A bare `Protocol.connect()` (no HTTP
+ * layer) negotiates the legacy 2025 handshake by default, so this harness
+ * exercises `elicit_echo` over that era. Its handler code (`inputRequired()` /
+ * `ctx.mcpReq.inputResponses`) is era-agnostic — the SDK translates the same
+ * calls into whichever wire representation the connection negotiated — so
+ * this is still a real test of the tool logic; see the "modern era" describe
+ * block below for an end-to-end test of the 2026-07-28 multi-round-trip wire
+ * path through the actual `createMcpHandler` production entry point.
+ *
+ * A single helper covers every case:
  *   - pass an `elicitHandler` to answer elicitation requests
  *   - set `supportsElicitation: false` to test the unsupported-client path
  *   - pass `onLog` to capture outbound logging notifications
@@ -58,15 +67,17 @@ async function setupClientServer(options: SetupOptions = {}) {
   );
 
   if (elicitHandler) {
-    client.setRequestHandler(ElicitRequestSchema, async (request) => {
+    client.setRequestHandler("elicitation/create", async (request: ElicitRequest) => {
       return elicitHandler({ message: request.params.message });
     });
   }
 
   if (onLog) {
-    client.setNotificationHandler(LoggingMessageNotificationSchema, (notification) => {
-      onLog(notification.params);
-    });
+    client.fallbackNotificationHandler = async (notification) => {
+      if (notification.method === "notifications/message") {
+        onLog(notification.params as { level: string; data: unknown; logger?: string });
+      }
+    };
   }
 
   await server.connect(serverTransport);
@@ -76,15 +87,10 @@ async function setupClientServer(options: SetupOptions = {}) {
   return harness;
 }
 
-function parseContent(result: unknown): Record<string, unknown> {
-  const parsed = CallToolResultSchema.safeParse(result);
-  expect(parsed.success).toBe(true);
-  if (!parsed.success) {
-    throw new Error("callTool result did not match CallToolResult schema");
-  }
-  const item = parsed.data.content[0];
-  expect(item.type).toBe("text");
-  if (item.type !== "text") {
+function parseContent(result: CallToolResult): Record<string, unknown> {
+  const item = result.content[0];
+  expect(item?.type).toBe("text");
+  if (item?.type !== "text") {
     throw new Error("expected text content");
   }
   return JSON.parse(item.text);
@@ -197,8 +203,81 @@ describe("elicit_echo tool", () => {
       arguments: {},
     });
 
-    const parsed = parseContent(result);
-    expect(parsed.error).toMatch(/elicitation/i);
+    // The SDK itself rejects the embedded elicitation request before our
+    // handler's inputResponse() ever sees a retry — it never reaches our own
+    // createErrorResult, so the message here is SDK-formatted, not ours.
+    const item = result.content[0];
+    expect(item?.type).toBe("text");
+    if (item?.type === "text") {
+      expect(item.text).toMatch(/elicitation/i);
+    }
     expect(result.isError).toBe(true);
+  });
+});
+
+describe("elicit_echo tool (2026-07-28 modern era)", () => {
+  /**
+   * The in-memory harness above negotiates the legacy 2025 handshake by
+   * default. These tests instead go through `createMcpHandler` — the actual
+   * production entry point wired up in src/index.ts — via a
+   * `StreamableHTTPClientTransport` whose `fetch` is bridged directly to the
+   * handler in-process (no real network), with the client pinned to the
+   * 2026-07-28 era. This confirms the multi-round-trip
+   * (`inputRequired`/`inputResponses`) path actually works end-to-end on the
+   * wire format this migration introduces, not just against the tool
+   * function in isolation.
+   */
+  async function setupModernEraClient(options: { supportsElicitation?: boolean } = {}) {
+    const { supportsElicitation = true } = options;
+
+    const server = new McpServer(
+      { name: "test-server", version: "0.0.0" },
+      { capabilities: { logging: {} } },
+    );
+    registerTools(server);
+
+    const handler = createMcpHandler(() => server);
+    const transport = new StreamableHTTPClientTransport(new URL("http://localhost/mcp"), {
+      fetch: async (input, init) => handler.fetch(new Request(input, init)),
+    });
+
+    const client = new Client(
+      { name: "test-client", version: "0.0.0" },
+      {
+        capabilities: supportsElicitation ? { elicitation: {} } : {},
+        versionNegotiation: { mode: { pin: "2026-07-28" } },
+      },
+    );
+
+    await client.connect(transport);
+    expect(client.getProtocolEra()).toBe("modern");
+
+    return { client, handler };
+  }
+
+  it("echoes the message the user provides via elicitation", async () => {
+    const { client, handler } = await setupModernEraClient();
+    client.setRequestHandler("elicitation/create", async () => ({
+      action: "accept",
+      content: { message: "modern era hello" },
+    }));
+
+    const result = await client.callTool({ name: "elicit_echo", arguments: {} });
+
+    const parsed = parseContent(result);
+    expect(parsed.echo).toBe("modern era hello");
+    expect(result.isError).toBeFalsy();
+
+    await client.close();
+    await handler.close();
+  });
+
+  it("returns an error result when the client does not support elicitation", async () => {
+    const { client, handler } = await setupModernEraClient({ supportsElicitation: false });
+
+    await expect(client.callTool({ name: "elicit_echo", arguments: {} })).rejects.toThrow(/elicitation/i);
+
+    await client.close();
+    await handler.close();
   });
 });

--- a/src/tools.test.ts
+++ b/src/tools.test.ts
@@ -272,7 +272,7 @@ describe("elicit_echo tool (2026-07-28 modern era)", () => {
     await handler.close();
   });
 
-  it("returns an error result when the client does not support elicitation", async () => {
+  it("rejects the tool call when the client does not support elicitation", async () => {
     const { client, handler } = await setupModernEraClient({ supportsElicitation: false });
 
     await expect(client.callTool({ name: "elicit_echo", arguments: {} })).rejects.toThrow(/elicitation/i);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,19 +1,22 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { CallToolResult, ElicitRequestFormParams, ElicitResult } from "@modelcontextprotocol/sdk/types.js";
+import type { McpServer, CallToolResult, InputRequiredResult, ServerContext } from "@modelcontextprotocol/server";
+import { inputRequired, inputResponse } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import { createErrorResult, createTextResult } from "./lib/utils.ts";
 import { logger } from "./logger.ts";
 
-type ElicitInputFn = (params: ElicitRequestFormParams) => Promise<ElicitResult>;
 type SendLoggingMessageFn = (params: {
   level: "debug" | "info" | "notice" | "warning" | "error" | "critical" | "alert" | "emergency";
   data: unknown;
   logger?: string;
 }) => Promise<void>;
 
+const ELICIT_ECHO_MESSAGE_KEY = "message";
+
 /**
  * Registers all MCP tools on the server.
- * Called once per session from getServer() in src/index.ts.
+ * Called once per request from getServer() in src/index.ts (the 2026-07-28
+ * spec serves each request from a fresh instance — there is no per-connection
+ * session to register tools once for).
  */
 export function registerTools(server: McpServer): void {
   server.registerTool(
@@ -25,10 +28,10 @@ export function registerTools(server: McpServer): void {
       // (see createTextResult). The echo may be null when the user declines or
       // cancels, so `echo` is nullable and not required.
       // https://modelcontextprotocol.io/specification/2025-06-18/server/tools#output-schema
-      outputSchema: {
+      outputSchema: z.object({
         echo: z.string().nullable().describe("The echoed message, or null if none was provided"),
         reason: z.string().optional().describe("Why no message was echoed, when applicable"),
-      },
+      }),
       // Annotations are untrusted hints clients use for UX/safety. This tool
       // neither mutates state nor touches the outside world.
       // https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool
@@ -38,7 +41,7 @@ export function registerTools(server: McpServer): void {
         openWorldHint: false,
       },
     },
-    (extra) => elicitEcho(server.server.elicitInput.bind(server.server), extra),
+    (ctx) => elicitEcho(ctx),
   );
 
   server.registerTool(
@@ -50,85 +53,88 @@ export function registerTools(server: McpServer): void {
       // JSON Schema and validates incoming args for us. (Contrast with the
       // elicitation `requestedSchema` in elicitEcho, which must be hand-written
       // JSON Schema; see the comment there.)
-      inputSchema: {
+      inputSchema: z.object({
         message: z.string().describe("The message to echo back"),
-      },
-      outputSchema: {
+      }),
+      outputSchema: z.object({
         echo: z.string().describe("The echoed message"),
-      },
+      }),
       annotations: {
         readOnlyHint: true,
         idempotentHint: true,
         openWorldHint: false,
       },
     },
-    (args, extra) => echo(server.sendLoggingMessage.bind(server), args, extra),
+    (args, ctx) => echo(server.sendLoggingMessage.bind(server), args, ctx),
   );
 }
 
 /**
- * Asks the user what they want to echo via MCP elicitation, then echoes it back.
- * Handles all three elicitation outcomes: accept, decline, and cancel.
+ * Asks the user what they want to echo via MCP elicitation, then echoes it
+ * back. This is a multi-round-trip tool (protocol revision 2026-07-28): the
+ * first call has no `inputResponses` yet, so it returns an `inputRequired()`
+ * result carrying the embedded elicitation request. The client resolves that
+ * and retries the same tool call with the response attached — this handler
+ * runs again and reads it via `ctx.mcpReq.inputResponses` to produce the
+ * final result. (The older push-style `elicitInput()` call throws on a
+ * 2026-07-28-era request, which is why this can't be a single synchronous
+ * await like it was under the previous stateful spec.)
  */
-async function elicitEcho(
-  elicitInput: ElicitInputFn,
-  extra: { sessionId?: string; requestId: unknown },
-): Promise<CallToolResult> {
+function elicitEcho(ctx: ServerContext): CallToolResult | InputRequiredResult {
   const toolName = "elicit_echo";
-  const { sessionId, requestId } = extra;
-  try {
-    // Elicitation `requestedSchema` must be a hand-written, flat JSON Schema
-    // (the restricted subset the MCP spec allows: primitive properties only,
-    // no nesting). This is why we don't reuse a Zod schema here the way `echo`
-    // does for its inputSchema — elicitation intentionally accepts only this
-    // limited shape so clients can render a simple form.
-    // https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation#request-schema
-    const result = await elicitInput({
-      message: "What would you like to echo?",
-      requestedSchema: {
-        type: "object",
-        properties: {
-          message: {
-            type: "string",
-            title: "Message",
-            description: "The message to echo back",
+  const requestId = ctx.mcpReq.id;
+  const response = inputResponse(ctx.mcpReq.inputResponses, ELICIT_ECHO_MESSAGE_KEY);
+
+  if (response.kind === "missing") {
+    return inputRequired({
+      inputRequests: {
+        [ELICIT_ECHO_MESSAGE_KEY]: inputRequired.elicit({
+          message: "What would you like to echo?",
+          // Elicitation `requestedSchema` must be a hand-written, flat JSON
+          // Schema (the restricted subset the MCP spec allows: primitive
+          // properties only, no nesting).
+          // https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation#request-schema
+          requestedSchema: {
+            type: "object",
+            properties: {
+              message: {
+                type: "string",
+                title: "Message",
+                description: "The message to echo back",
+              },
+            },
+            required: ["message"],
           },
-        },
-        required: ["message"],
+        }),
       },
     });
-
-    if (result.action === "accept") {
-      if (!result.content) {
-        logger.warn({ toolName, sessionId, requestId }, "Accept response missing content");
-        // A genuine failure: the client claimed acceptance but sent nothing.
-        return createErrorResult({ error: "Accepted but no content was returned" });
-      }
-      const data = { echo: result.content.message };
-      logger.info({ toolName, sessionId, requestId }, "Tool executed");
-      return createTextResult(data);
-    }
-
-    // Decline and cancel are valid user outcomes, not errors — return them as
-    // normal results (no isError) so the model treats them as a real answer.
-    if (result.action === "decline") {
-      logger.info({ toolName, sessionId, requestId, action: "decline" }, "User declined elicitation");
-      return createTextResult({ echo: null, reason: "User declined to provide a message" });
-    }
-
-    logger.info({ toolName, sessionId, requestId, action: "cancel" }, "User cancelled elicitation");
-    return createTextResult({ echo: null, reason: "Elicitation was cancelled" });
-  } catch (error) {
-    // Reaching here means elicitation itself failed (e.g. the client doesn't
-    // support it) — a genuine execution error.
-    logger.error(
-      { toolName, sessionId, requestId, error: error instanceof Error ? error.message : String(error) },
-      "Tool execution failed",
-    );
-    return createErrorResult({
-      error: error instanceof Error ? error.message : String(error),
-    });
   }
+
+  // Decline and cancel are valid user outcomes, not errors — return them as
+  // normal results (no isError) so the model treats them as a real answer.
+  if (response.kind !== "elicit") {
+    logger.error({ toolName, requestId, kind: response.kind }, "Tool execution failed");
+    return createErrorResult({ error: "Expected an elicitation response" });
+  }
+
+  if (response.action === "decline") {
+    logger.info({ toolName, requestId, action: "decline" }, "User declined elicitation");
+    return createTextResult({ echo: null, reason: "User declined to provide a message" });
+  }
+
+  if (response.action === "cancel") {
+    logger.info({ toolName, requestId, action: "cancel" }, "User cancelled elicitation");
+    return createTextResult({ echo: null, reason: "Elicitation was cancelled" });
+  }
+
+  const accepted = z.object({ message: z.string() }).safeParse(response.content);
+  if (!accepted.success) {
+    logger.warn({ toolName, requestId }, "Accept response missing content");
+    return createErrorResult({ error: "Accepted but no content was returned" });
+  }
+
+  logger.info({ toolName, requestId }, "Tool executed");
+  return createTextResult({ echo: accepted.data.message });
 }
 
 /**
@@ -138,10 +144,10 @@ async function elicitEcho(
 async function echo(
   sendLoggingMessage: SendLoggingMessageFn,
   args: { message: string },
-  extra: { sessionId?: string; requestId: unknown },
+  ctx: ServerContext,
 ): Promise<CallToolResult> {
   const toolName = "echo";
-  const { sessionId, requestId } = extra;
+  const requestId = ctx.mcpReq.id;
   // Example: send an MCP log notification to the client. The client
   // controls which levels it receives via logging/setLevel.
   // See: https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/logging
@@ -160,6 +166,6 @@ async function echo(
   }
 
   const data = { echo: args.message };
-  logger.info({ toolName, sessionId, requestId }, "Tool executed");
+  logger.info({ toolName, requestId }, "Tool executed");
   return createTextResult(data);
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,10 +12,8 @@ export default defineConfig(({ command }) => ({
     },
     rolldownOptions: {
       external: [
-        "@modelcontextprotocol/sdk",
-        "@modelcontextprotocol/sdk/server/mcp.js",
-        "@modelcontextprotocol/sdk/server/streamableHttp.js",
-        "@modelcontextprotocol/sdk/types.js",
+        "@modelcontextprotocol/server",
+        "@modelcontextprotocol/node",
         "express",
         "zod",
         "node:crypto",
@@ -52,6 +50,6 @@ export default defineConfig(({ command }) => ({
     },
   },
   ssr: {
-    external: ["@modelcontextprotocol/sdk", "express", "zod"],
+    external: ["@modelcontextprotocol/server", "@modelcontextprotocol/node", "express", "zod"],
   },
 }));


### PR DESCRIPTION
## Summary

Migrates from `@modelcontextprotocol/sdk` (v1, stateful) to the new `@modelcontextprotocol/server` / `@modelcontextprotocol/node` (v2.0.0) packages implementing the MCP 2026-07-28 spec revision, per #issue draft: no `initialize`/`initialized` handshake, no `Mcp-Session-Id`, protocol version/client identity/capabilities travel per-request instead of being negotiated once per connection.

- **`src/index.ts`** — replaced the hand-rolled `transports` session map and manual POST/GET/DELETE branching with `createMcpHandler` + `toNodeHandler`, mounted on Express. Added a dedicated `GET /health` liveness endpoint since `GET /mcp` no longer doubles as one.
- **`src/tools.ts`** — `registerTool`'s callback param is now `ctx` (`ServerContext`), not `extra`; dropped `sessionId` (no longer meaningful) in favor of `ctx.mcpReq.id`. Rewrote `elicit_echo` from the old synchronous `elicitInput()` push request (which **throws** on a 2026-07-28-era request) to the new `inputRequired()`/`inputResponse()` multi-round-trip pattern. `inputSchema`/`outputSchema` now use `z.object()` (the bare-shape form is deprecated in v2).
- **`src/tools.test.ts`** — updated for `@modelcontextprotocol/client`; added an explicit modern-era (2026-07-28) end-to-end test through the real `createMcpHandler` production entry point (via a fetch-bridged `StreamableHTTPClientTransport`), alongside the existing legacy-era in-memory harness — both wire eras are covered.
- **`docker-compose.yml`** — healthcheck now targets `/health` instead of `/mcp`.
- Updated `README.md`, `AGENTS.md`, and the `create-mcp-tool` skill to match.

### On backward compatibility

`createMcpHandler`'s default `legacy: 'stateless'` mode serves 2025-era clients automatically. So this is **not** a client-compatibility break — no dual-transport wiring was needed. The breaking change is at the dependency/developer level only (package swap, `extra` → `ctx`, `elicitInput()` → `inputRequired()` for anything that forked this template's old pattern).

### Manual verification

**1. A legacy 2025-era client still round-trips correctly.** Sending an old-style `initialize` handshake with `protocolVersion: "2025-06-18"` gets that same version echoed back — the server negotiates down to match the client instead of forcing an upgrade, so nothing forked from the old stateful pattern breaks:

```bash
curl -s http://localhost:3000/mcp \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"1.0.0"}}}'

event: message
data: {"result":{"protocolVersion":"2025-06-18","capabilities":{"logging":{},"tools":{"listChanged":true}},"serverInfo":{"name":"mcp-typescript-template","version":"1.0.0"}},"jsonrpc":"2.0","id":1}
```

**2. A real 2026-07-28 client needs no handshake at all.** Per the new spec, `initialize`/`initialized` is gone entirely — a modern client goes straight to a method like `tools/list`, with no session id and no prior negotiation step:

```bash
curl -s http://localhost:3000/mcp \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'

event: message
data: {"result":{"tools":[{"name":"elicit_echo", ...}, {"name":"echo", ...}]},"jsonrpc":"2.0","id":1}
```

Both requests hit the same `/mcp` endpoint and the same `createMcpHandler` instance — the legacy fallback and the stateless modern path coexist without any dual-transport wiring.

## Related Issues

Close #92

## Test plan

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run build`
- [x] `npm run test:ci` (17/17 passing, including new modern-era elicitation tests)
- [x] Manual smoke test of the built server: `GET /health` → 200, `GET /mcp` → 405 (no session), legacy `POST /mcp initialize` (`protocolVersion: 2025-06-18`) → valid response, `POST /mcp tools/list` with no handshake → valid response

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stateless MCP request handling with improved compatibility for legacy clients.
  * Added a dedicated `/health` endpoint for service monitoring.
  * Improved interactive tool responses with retry and cancellation handling.
  * Added request-scoped logging and graceful shutdown behavior.

* **Documentation**
  * Updated setup, architecture, tool-authoring, testing, and health-check guidance for the current MCP API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->